### PR TITLE
Support `across()`

### DIFF
--- a/R/utils-polars.R
+++ b/R/utils-polars.R
@@ -14,7 +14,7 @@ pl_colnames <- function(x) {
 
 check_polars_data <- function(x) {
   if (!inherits(x, "DataFrame") && !inherits(x, "LazyFrame")
-      && !inherits(x, "GroupBy")) {
+      && !inherits(x, "GroupBy") && !inherits(x, "LazyGroupBy")) {
     stop("The data must be a Polars DataFrame or LazyFrame.")
   }
 }

--- a/tests/tinytest/test_across.R
+++ b/tests/tinytest/test_across.R
@@ -1,0 +1,96 @@
+source("helpers.R")
+using("tidypolars")
+
+test <- as_polars(mtcars)
+
+# single word function
+
+expect_equal(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      mean
+    ),
+    cyl = cyl + 1
+  ),
+  pl_mutate(
+    test,
+    drat = mean(drat),
+    am = mean(am),
+    gear = mean(gear),
+    carb = mean(carb),
+    cyl = cyl + 1
+  )
+)
+
+# purrr-style function
+
+expect_equal(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      ~ mean(.x)
+    ),
+    cyl = cyl + 1
+  ),
+  pl_mutate(
+    test,
+    drat = mean(drat),
+    am = mean(am),
+    gear = mean(gear),
+    carb = mean(carb),
+    cyl = cyl + 1
+  )
+)
+
+# argument .names
+
+expect_colnames(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      mean,
+      .names = "{.col}_new"
+    ),
+    cyl = cyl + 1
+  ),
+  c(
+    "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "gear", "carb",
+    "drat_new", "am_new", "gear_new", "carb_new"
+  )
+)
+
+expect_colnames(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      mean,
+      .names = "{.fn}_{.col}"
+    ),
+    cyl = cyl + 1
+  ),
+  c(
+    "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "gear", "carb",
+    "mean_drat", "mean_am", "mean_gear", "mean_carb"
+  )
+)
+
+expect_colnames(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      ~mean(.x),
+      .names = "{.fn}_{.col}"
+    ),
+    cyl = cyl + 1
+  ),
+  c(
+    "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "gear", "carb",
+    "mean_drat", "mean_am", "mean_gear", "mean_carb"
+  )
+)

--- a/tests/tinytest/test_across.R
+++ b/tests/tinytest/test_across.R
@@ -1,7 +1,7 @@
 source("helpers.R")
 using("tidypolars")
 
-test <- as_polars(mtcars)
+test <- polars:::pl$DataFrame(head(mtcars))
 
 # single word function
 
@@ -44,6 +44,24 @@ expect_equal(
     cyl = cyl + 1
   )
 )
+
+# groups
+
+# TODO: uncomment this when https://github.com/pola-rs/r-polars/issues/338 is
+# solved
+# expect_equal(
+#   test |>
+#     pl_group_by(am) |>
+#     pl_mutate(
+#       across(
+#         .cols = contains("a"),
+#         ~ mean(.x)
+#       )
+#     ) |>
+#     pl_pull(carb),
+#   c(3, 3, 3, 1.333, 1.333, 1.333),
+#   tolerance = 1e-3
+# )
 
 # argument .names
 

--- a/tests/tinytest/test_across_lazy.R
+++ b/tests/tinytest/test_across_lazy.R
@@ -1,0 +1,102 @@
+### [GENERATED AUTOMATICALLY] Update test_across.R instead.
+
+Sys.setenv('TIDYPOLARS_TEST' = TRUE)
+
+source("helpers.R")
+using("tidypolars")
+
+test <- as_polars(mtcars)
+
+# single word function
+
+expect_equal_lazy(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      mean
+    ),
+    cyl = cyl + 1
+  ),
+  pl_mutate(
+    test,
+    drat = mean(drat),
+    am = mean(am),
+    gear = mean(gear),
+    carb = mean(carb),
+    cyl = cyl + 1
+  )
+)
+
+# purrr-style function
+
+expect_equal_lazy(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      ~ mean(.x)
+    ),
+    cyl = cyl + 1
+  ),
+  pl_mutate(
+    test,
+    drat = mean(drat),
+    am = mean(am),
+    gear = mean(gear),
+    carb = mean(carb),
+    cyl = cyl + 1
+  )
+)
+
+# argument .names
+
+expect_colnames(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      mean,
+      .names = "{.col}_new"
+    ),
+    cyl = cyl + 1
+  ),
+  c(
+    "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "gear", "carb",
+    "drat_new", "am_new", "gear_new", "carb_new"
+  )
+)
+
+expect_colnames(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      mean,
+      .names = "{.fn}_{.col}"
+    ),
+    cyl = cyl + 1
+  ),
+  c(
+    "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "gear", "carb",
+    "mean_drat", "mean_am", "mean_gear", "mean_carb"
+  )
+)
+
+expect_colnames(
+  pl_mutate(
+    test,
+    across(
+      .cols = contains("a"),
+      ~mean(.x),
+      .names = "{.fn}_{.col}"
+    ),
+    cyl = cyl + 1
+  ),
+  c(
+    "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "gear", "carb",
+    "mean_drat", "mean_am", "mean_gear", "mean_carb"
+  )
+)
+
+Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/tinytest/test_across_lazy.R
+++ b/tests/tinytest/test_across_lazy.R
@@ -5,7 +5,7 @@ Sys.setenv('TIDYPOLARS_TEST' = TRUE)
 source("helpers.R")
 using("tidypolars")
 
-test <- as_polars(mtcars)
+test <- polars:::pl$LazyFrame(head(mtcars))
 
 # single word function
 
@@ -48,6 +48,24 @@ expect_equal_lazy(
     cyl = cyl + 1
   )
 )
+
+# groups
+
+# TODO: uncomment this when https://github.com/pola-rs/r-polars/issues/338 is
+# solved
+# expect_equal_lazy(
+#   test |>
+#     pl_group_by(am) |>
+#     pl_mutate(
+#       across(
+#         .cols = contains("a"),
+#         ~ mean(.x)
+#       )
+#     ) |>
+#     pl_pull(carb),
+#   c(3, 3, 3, 1.333, 1.333, 1.333),
+#   tolerance = 1e-3
+# )
 
 # argument .names
 


### PR DESCRIPTION
Close #12 

Only works for "single-word" functions for now (not anonymous functions):
``` r
library(tidypolars)

mtcars |> 
  head() |> 
  as_polars() |>
  pl_mutate(
    across(
      .cols = contains("a"),
      mean
    ),
    cyl = cyl + 1
  )
#> shape: (6, 11)
#> ┌──────┬─────┬───────┬───────┬───┬─────┬─────┬──────┬──────────┐
#> │ mpg  ┆ cyl ┆ disp  ┆ hp    ┆ … ┆ vs  ┆ am  ┆ gear ┆ carb     │
#> │ ---  ┆ --- ┆ ---   ┆ ---   ┆   ┆ --- ┆ --- ┆ ---  ┆ ---      │
#> │ f64  ┆ f64 ┆ f64   ┆ f64   ┆   ┆ f64 ┆ f64 ┆ f64  ┆ f64      │
#> ╞══════╪═════╪═══════╪═══════╪═══╪═════╪═════╪══════╪══════════╡
#> │ 21.0 ┆ 7.0 ┆ 160.0 ┆ 110.0 ┆ … ┆ 0.0 ┆ 0.5 ┆ 3.5  ┆ 2.166667 │
#> │ 21.0 ┆ 7.0 ┆ 160.0 ┆ 110.0 ┆ … ┆ 0.0 ┆ 0.5 ┆ 3.5  ┆ 2.166667 │
#> │ 22.8 ┆ 5.0 ┆ 108.0 ┆ 93.0  ┆ … ┆ 1.0 ┆ 0.5 ┆ 3.5  ┆ 2.166667 │
#> │ 21.4 ┆ 7.0 ┆ 258.0 ┆ 110.0 ┆ … ┆ 1.0 ┆ 0.5 ┆ 3.5  ┆ 2.166667 │
#> │ 18.7 ┆ 9.0 ┆ 360.0 ┆ 175.0 ┆ … ┆ 0.0 ┆ 0.5 ┆ 3.5  ┆ 2.166667 │
#> │ 18.1 ┆ 7.0 ┆ 225.0 ┆ 105.0 ┆ … ┆ 1.0 ┆ 0.5 ┆ 3.5  ┆ 2.166667 │
#> └──────┴─────┴───────┴───────┴───┴─────┴─────┴──────┴──────────┘
```

<sup>Created on 2023-07-25 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>