### PR TITLE
Fix sequential expressions 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@
 * The argument `with_string_cache` in `as_polars()` now enables the string cache
   globally if set to `TRUE` (#54).
   
+**Bug fixes**
+
+* Improve robustness of sequential expressions in `mutate()` and `summarize()` 
+  (i.e expressions that should be run one after the other because they depend on
+  variables created in the same call) (#58).
+  
 **Misc**
 
 * Error messages coming from `mutate()`, `summarize()`, and `filter()` now give 

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -111,7 +111,6 @@ pl_is_between <- function(x, left, right, include_bounds = TRUE, ...) {
 }
 
 pl_case_match <- function(x, ..., .data) {
-  dots <- get_dots(...)
   env <- env_from_dots(...)
   new_vars <- new_vars_from_dots(...)
   dots <- clean_dots(...)
@@ -142,7 +141,6 @@ pl_case_match <- function(x, ..., .data) {
 }
 
 pl_case_when <- function(..., .data) {
-  dots <- get_dots(...)
   env <- env_from_dots(...)
   new_vars <- new_vars_from_dots(...)
   dots <- clean_dots(...)

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -55,27 +55,33 @@ pl_approx_unique <- function(x, ...) {
   x$approx_unique()
 }
 
-pl_arccos <- function(x) {
+pl_arccos <- function(x, ...) {
+  check_empty_dots()
   x$arccos()
 }
 
-pl_arccosh <- function(x) {
+pl_arccosh <- function(x, ...) {
+  check_empty_dots()
   x$arccosh()
 }
 
-pl_arcsin <- function(x) {
+pl_arcsin <- function(x, ...) {
+  check_empty_dots()
   x$arcsin()
 }
 
-pl_arcsinh <- function(x) {
+pl_arcsinh <- function(x, ...) {
+  check_empty_dots()
   x$arcsinh()
 }
 
-pl_arctan <- function(x) {
+pl_arctan <- function(x, ...) {
+  check_empty_dots()
   x$arctan()
 }
 
-pl_arctanh <- function(x) {
+pl_arctanh <- function(x, ...) {
+  check_empty_dots()
   x$arctanh()
 }
 
@@ -106,6 +112,10 @@ pl_is_between <- function(x, left, right, include_bounds = TRUE, ...) {
 
 pl_case_match <- function(x, ..., .data) {
   dots <- get_dots(...)
+  env <- dots$env
+  new_vars <- dots$new_vars
+  dots$env <- NULL
+  dots$new_vars <- NULL
 
   x <- polars::pl$col(deparse(substitute(x)))
 
@@ -116,12 +126,12 @@ pl_case_match <- function(x, ..., .data) {
   out <- NULL
   for (y in seq_along(dots)) {
     if (y == length(dots)) {
-      otw <- translate_expr(.data, dots[[y]])
+      otw <- translate_expr(.data, dots[[y]], new_vars = new_vars, env = env)
       out <- out$otherwise(otw)
       next
     }
-    lhs <- translate_expr(.data, dots[[y]][[2]])
-    rhs <- translate_expr(.data, dots[[y]][[3]])
+    lhs <- translate_expr(.data, dots[[y]][[2]], new_vars = new_vars, env = env)
+    rhs <- translate_expr(.data, dots[[y]][[3]], new_vars = new_vars, env = env)
     if (is.null(out)) {
       out <- polars::pl$when(x$is_in(lhs))$then(rhs)
     } else {
@@ -132,10 +142,12 @@ pl_case_match <- function(x, ..., .data) {
   out
 }
 
-
-
 pl_case_when <- function(..., .data) {
   dots <- get_dots(...)
+  env <- dots$env
+  new_vars <- dots$new_vars
+  dots$env <- NULL
+  dots$new_vars <- NULL
 
   if (!".default" %in% names(dots)) {
     dots[[length(dots) + 1]] <- c(".default" = NA)
@@ -144,12 +156,12 @@ pl_case_when <- function(..., .data) {
   out <- NULL
   for (y in seq_along(dots)) {
     if (y == length(dots)) {
-      otw <- translate_expr(.data, dots[[y]])
+      otw <- translate_expr(.data, dots[[y]], new_vars = new_vars, env = env)
       out <- out$otherwise(otw)
       next
     }
-    lhs <- translate_expr(.data, dots[[y]][[2]])
-    rhs <- translate_expr(.data, dots[[y]][[3]])
+    lhs <- translate_expr(.data, dots[[y]][[2]], new_vars = new_vars, env = env)
+    rhs <- translate_expr(.data, dots[[y]][[3]], new_vars = new_vars, env = env)
 
     if (is.null(out)) {
       out <- polars::pl$when(lhs)$then(rhs)
@@ -171,14 +183,16 @@ pl_clip <- function(x, ...) {
 }
 
 pl_coalesce <- function(..., default = NULL) {
-  pl$coalesce(..., default)
+  pl$coalesce(clean_dots(...), default)
 }
 
-pl_cos <- function(x) {
+pl_cos <- function(x, ...) {
+  check_empty_dots()
   x$cos()
 }
 
-pl_cosh <- function(x) {
+pl_cosh <- function(x, ...) {
+  check_empty_dots()
   x$cosh()
 }
 
@@ -237,10 +251,14 @@ pl_hash <- function(x, ...) {
   x$hash()
 }
 
-pl_ifelse <- function(cond, yes, no, .data) {
-  cond <- translate_expr(.data, enexpr(cond))
-  yes <- translate_expr(.data, enexpr(yes))
-  no <- translate_expr(.data, enexpr(no))
+pl_ifelse <- function(cond, yes, no, .data, ...) {
+  check_empty_dots(...)
+  env <- env_from_dots(...)
+  new_vars <- new_vars_from_dots(...)
+
+  cond <- translate_expr(.data, enexpr(cond), new_vars = new_vars, env = env)
+  yes <- translate_expr(.data, enexpr(yes), new_vars = new_vars, env = env)
+  no <- translate_expr(.data, enexpr(no), new_vars = new_vars, env = env)
   pl$when(cond)$then(yes)$otherwise(no)
 }
 
@@ -410,11 +428,13 @@ pl_sum <- function(x, ...) {
   x$sum()
 }
 
-pl_tan <- function(x) {
+pl_tan <- function(x, ...) {
+  check_empty_dots()
   x$tan()
 }
 
-pl_tanh <- function(x) {
+pl_tanh <- function(x, ...) {
+  check_empty_dots()
   x$tanh()
 }
 

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -112,10 +112,9 @@ pl_is_between <- function(x, left, right, include_bounds = TRUE, ...) {
 
 pl_case_match <- function(x, ..., .data) {
   dots <- get_dots(...)
-  env <- dots$env
-  new_vars <- dots$new_vars
-  dots$env <- NULL
-  dots$new_vars <- NULL
+  env <- env_from_dots(...)
+  new_vars <- new_vars_from_dots(...)
+  dots <- clean_dots(...)
 
   x <- polars::pl$col(deparse(substitute(x)))
 
@@ -144,10 +143,9 @@ pl_case_match <- function(x, ..., .data) {
 
 pl_case_when <- function(..., .data) {
   dots <- get_dots(...)
-  env <- dots$env
-  new_vars <- dots$new_vars
-  dots$env <- NULL
-  dots$new_vars <- NULL
+  env <- env_from_dots(...)
+  new_vars <- new_vars_from_dots(...)
+  dots <- clean_dots(...)
 
   if (!".default" %in% names(dots)) {
     dots[[length(dots) + 1]] <- c(".default" = NA)

--- a/R/funs-string.R
+++ b/R/funs-string.R
@@ -133,7 +133,7 @@ pl_str_remove_all <- function(string, pattern, ...) {
 }
 
 pl_paste0 <- function(..., collapse = NULL) {
-  pl$concat_str(clean_dots(...))
+  pl_paste(..., sep = "", collapse = collapse)
 }
 
 pl_paste <- function(..., sep = " ", collapse = NULL) {
@@ -142,8 +142,9 @@ pl_paste <- function(..., sep = " ", collapse = NULL) {
   if (!is.character(sep)) {
     sep <- sep$to_r()
   }
-  browser()
-  pl$concat_str(clean_dots(...), separator = sep)
+  # pl$concat_str() doesn't support a list input, which is problematic since
+  # clean_dots() has to return a list
+  pl$concat_list(clean_dots(...))$list$join(separator = sep)
 }
 
 pl_str_trim <- function(string, side = "both", ...) {

--- a/R/funs-string.R
+++ b/R/funs-string.R
@@ -1,5 +1,6 @@
 
-pl_str_detect <- function(string, pattern, negate = FALSE) {
+pl_str_detect <- function(string, pattern, negate = FALSE, ...) {
+  check_empty_dots(...)
   out <- string$str$contains(pattern)
   if (isTRUE(negate)) {
     out$is_not()
@@ -19,7 +20,8 @@ pl_str_count_matches <- function(string, pattern = "", ...) {
   string$str$count_matches(pattern, literal = is_fixed)
 }
 
-pl_str_ends <- function(string, pattern, negate = FALSE) {
+pl_str_ends <- function(string, pattern, negate = FALSE, ...) {
+  check_empty_dots(...)
   out <- string$str$ends_with(pattern)
   if (isTRUE(negate)) {
     out$is_not()
@@ -29,7 +31,8 @@ pl_str_ends <- function(string, pattern, negate = FALSE) {
 }
 
 # group = 0 means the whole match
-pl_str_extract <- function(string, pattern, group = 0) {
+pl_str_extract <- function(string, pattern, group = 0, ...) {
+  check_empty_dots(...)
   string$str$extract(pattern, group_index = group)
 }
 
@@ -83,7 +86,8 @@ pl_str_slice <- function(string, start, end = NULL, ...) {
 #   string$str$splitn()
 # }
 
-pl_str_starts <- function(string, pattern, negate = FALSE) {
+pl_str_starts <- function(string, pattern, negate = FALSE, ...) {
+  check_empty_dots(...)
   if (isTRUE(negate)) {
     string$str$starts_with(pl$lit(pattern))$is_not()
   } else {
@@ -129,7 +133,7 @@ pl_str_remove_all <- function(string, pattern, ...) {
 }
 
 pl_paste0 <- function(..., collapse = NULL) {
-  pl$concat_str(...)
+  pl$concat_str(clean_dots(...))
 }
 
 pl_paste <- function(..., sep = " ", collapse = NULL) {
@@ -138,10 +142,12 @@ pl_paste <- function(..., sep = " ", collapse = NULL) {
   if (!is.character(sep)) {
     sep <- sep$to_r()
   }
-  pl$concat_str(..., separator = sep)
+  browser()
+  pl$concat_str(clean_dots(...), separator = sep)
 }
 
-pl_str_trim <- function(string, side = "both") {
+pl_str_trim <- function(string, side = "both", ...) {
+  check_empty_dots(...)
   switch(
     side,
     "both" = string$str$strip_chars(),
@@ -155,7 +161,8 @@ pl_trimws <- function(string, which = "both", ...) {
   pl_str_trim(string, side = which)
 }
 
-pl_str_pad <- function(string, width, side = "left", pad = " ", use_width = TRUE) {
+pl_str_pad <- function(string, width, side = "left", pad = " ", use_width = TRUE, ...) {
+  check_empty_dots(...)
   if (isFALSE(use_width)) {
     abort(
       '`str_pad()` doesn\'t work in a Polars DataFrame when `use_width = FALSE`',
@@ -176,10 +183,12 @@ pl_str_pad <- function(string, width, side = "left", pad = " ", use_width = TRUE
 
 # not in polars
 
-pl_word <- function(string, start = 1L, end = start, sep = " ") {
+pl_word <- function(string, start = 1L, end = start, sep = " ", ...) {
+  check_empty_dots(...)
   string$str$split(sep)$list$take((start:end) - 1L)$list$join(sep)
 }
 
-pl_str_squish <- function(string) {
+pl_str_squish <- function(string, ...) {
+  check_empty_dots(...)
   string$str$replace_all("\\s+", " ")$str$strip_chars()
 }

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -4,7 +4,7 @@ translate_dots <- function(.data, ..., env) {
   dots <- enexprs(...)
   new_vars <- c()
   out <- lapply(seq_along(dots), \(x) {
-    tmp <- translate_expr(.data = .data, dots[[x]], new_vars, env = env)
+    tmp <- translate_expr(.data = .data, dots[[x]], new_vars = new_vars, env = env)
     new_vars <<- c(new_vars, names(dots)[x])
     tmp
   })
@@ -22,7 +22,7 @@ translate_dots <- function(.data, ..., env) {
   out
 }
 
-translate_expr <- function(.data, quo, new_vars, env) {
+translate_expr <- function(.data, quo, env, new_vars = NULL) {
 
   names_data <- pl_colnames(.data)
 
@@ -51,7 +51,7 @@ translate_expr <- function(.data, quo, new_vars, env) {
     expr <- unpack_across(.data, expr)
   }
 
-  translate <- function(expr, env) {
+  translate <- function(expr, new_vars, env) {
 
     # prepare function and arg if the user provided an anonymous function in
     # across()
@@ -201,7 +201,7 @@ translate_expr <- function(.data, quo, new_vars, env) {
           }
         }
 
-        args <- lapply(as.list(expr[-1]), translate, env = env)
+        args <- lapply(as.list(expr[-1]), translate, new_vars = new_vars, env = env)
         if (name %in% known_functions) {
           name <- r_polars_funs$polars_funs[r_polars_funs$r_funs == name][1]
           name <- paste0("pl_", name)
@@ -235,9 +235,9 @@ translate_expr <- function(.data, quo, new_vars, env) {
 
   # happens because across() calls get split earlier
   if ((is.vector(expr) && length(expr) > 1) || is.list(expr)) {
-    lapply(expr, translate, env = env)
+    lapply(expr, translate, new_vars = new_vars, env = env)
   } else {
-    translate(expr, env = env)
+    translate(expr, new_vars = new_vars, env = env)
   }
 }
 

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -112,15 +112,15 @@ translate_expr <- function(.data, quo, new_vars = NULL, env) {
           "case_match" =  {
             args <- call_args(expr)
             args$.data <- .data
-            args$new_vars <- as.list(new_vars)
-            args$env <- env
+            args[["__tidypolars__new_vars"]] <- as.list(new_vars)
+            args[["__tidypolars__env"]] <- env
             return(do.call(pl_case_match, args))
           },
           "case_when" = {
             args <- call_args(expr)
             args$.data <- .data
-            args$new_vars <- as.list(new_vars)
-            args$env <- env
+            args[["__tidypolars__new_vars"]] <- as.list(new_vars)
+            args[["__tidypolars__env"]] <- env
             return(do.call(pl_case_when, args))
           },
           "c" = ,
@@ -146,8 +146,8 @@ translate_expr <- function(.data, quo, new_vars = NULL, env) {
           "if_else" =  {
             args <- call_args(expr)
             args$.data <- .data
-            args$new_vars <- as.list(new_vars)
-            args$env <- env
+            args[["__tidypolars__new_vars"]] <- as.list(new_vars)
+            args[["__tidypolars__env"]] <- env
             return(do.call(pl_ifelse, args))
           },
           "is.na" = {
@@ -222,8 +222,8 @@ translate_expr <- function(.data, quo, new_vars = NULL, env) {
            } else if (name %in% user_defined) {
              do.call(name, args)
            } else {
-             args$new_vars <- as.list(new_vars)
-             args$env <- env
+             args[["__tidypolars__new_vars"]] <- as.list(new_vars)
+             args[["__tidypolars__env"]] <- env
              do.call(name, args)
            }
           },
@@ -284,8 +284,8 @@ get_globenv_functions <- function() {
 # exists in the R function but will not be used in the polars function.
 check_empty_dots <- function(...) {
   dots <- get_dots(...)
-  dots$new_vars <- NULL
-  dots$env <- NULL
+  dots[["__tidypolars__new_vars"]] <- NULL
+  dots[["__tidypolars__env"]] <- NULL
   if (length(dots) > 0) {
     fn <- deparse(match.call(call = sys.call(sys.parent()))[1])
     fn <- gsub("^pl\\_", "", fn)
@@ -304,8 +304,8 @@ check_empty_dots <- function(...) {
 # apply directly `...`, such as paste()
 clean_dots <- function(...) {
   dots <- get_dots(...)
-  dots$new_vars <- NULL
-  dots$env <- NULL
+  dots[["__tidypolars__new_vars"]] <- NULL
+  dots[["__tidypolars__env"]] <- NULL
   dots
 }
 
@@ -313,12 +313,12 @@ clean_dots <- function(...) {
 # pl_ifelse())
 new_vars_from_dots <- function(...) {
   dots <- get_dots(...)
-  dots[["new_vars"]]
+  dots[["__tidypolars__new_vars"]]
 }
 
 env_from_dots <- function(...) {
   dots <- get_dots(...)
-  dots[["env"]]
+  dots[["__tidypolars__env"]]
 }
 
 # Return a list of all functions / operations we know

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -217,9 +217,7 @@ translate_expr <- function(.data, quo, new_vars = NULL, env) {
 
         tryCatch(
           {
-           if (name %in% known_ops) {
-             do.call(name, args)
-           } else if (name %in% user_defined) {
+           if (name %in% c(known_ops, user_defined)) {
              do.call(name, args)
            } else {
              args[["__tidypolars__new_vars"]] <- as.list(new_vars)

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -131,8 +131,8 @@ translate_expr <- function(.data, quo, new_vars = NULL, env) {
           "%in%" = {
             out <- tryCatch(
               {
-                lhs <- translate(expr[[2]], env = env)
-                rhs <- translate(expr[[3]], env = env)
+                lhs <- translate(expr[[2]], new_vars = new_vars, env = env)
+                rhs <- translate(expr[[3]], new_vars = new_vars, env = env)
                 if (is.list(rhs)) {
                   rhs <- unlist(rhs)
                 }
@@ -215,7 +215,6 @@ translate_expr <- function(.data, quo, new_vars = NULL, env) {
           name <- paste0("pl_", name)
         }
 
-        # browser()
         tryCatch(
           {
            if (name %in% known_ops) {

--- a/tests/tinytest/test_mutate.R
+++ b/tests/tinytest/test_mutate.R
@@ -248,3 +248,18 @@ expect_equal(
     x = 2
   )
 )
+
+
+# correct sequential operations
+
+expect_equal(
+  iris[c(1, 2, 149, 150), ] |>
+    as_polars() |>
+    mutate(
+      x = Sepal.Length > 6,
+      y = x & Species == "virginica",
+      z = ifelse(y, Petal.Width, Petal.Length * Sepal.Width)
+    ) |>
+    pull(z),
+  c(4.9, 4.2, 2.3, 15.3)
+)

--- a/tests/tinytest/test_mutate_lazy.R
+++ b/tests/tinytest/test_mutate_lazy.R
@@ -253,4 +253,19 @@ expect_equal_lazy(
   )
 )
 
+
+# correct sequential operations
+
+expect_equal_lazy(
+  iris[c(1, 2, 149, 150), ] |>
+    as_polars() |>
+    mutate(
+      x = Sepal.Length > 6,
+      y = x & Species == "virginica",
+      z = ifelse(y, Petal.Width, Petal.Length * Sepal.Width)
+    ) |>
+    pull(z),
+  c(4.9, 4.2, 2.3, 15.3)
+)
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/tinytest/test_utils-expr.R
+++ b/tests/tinytest/test_utils-expr.R
@@ -12,7 +12,7 @@ expect_equal(
     x = NULL,
     mean_pl = mean(Petal.Length),
     foo = Sepal.Width + Petal.Width,
-    env = current_env()
+    env = rlang::current_env()
   ),
   list(
     pool_exprs_1 = list(
@@ -35,7 +35,7 @@ expect_equal(
     x = 1,
     x = 2,
     x = NULL,
-    env = current_env()
+    env = rlang::current_env()
   ),
   list(
     pool_exprs_1 = list(x = pl$lit(1)),
@@ -50,7 +50,7 @@ expect_equal(
     x = 1,
     x = "a",
     x = NULL,
-    env = current_env()
+    env = rlang::current_env()
   ),
   list(
     pool_exprs_1 = list(x = pl$lit(1)),

--- a/tests/tinytest/test_utils-expr.R
+++ b/tests/tinytest/test_utils-expr.R
@@ -11,7 +11,8 @@ expect_equal(
     Petal.Length = Petal.Length / x,
     x = NULL,
     mean_pl = mean(Petal.Length),
-    foo = Sepal.Width + Petal.Width
+    foo = Sepal.Width + Petal.Width,
+    env = current_env()
   ),
   list(
     pool_exprs_1 = list(
@@ -33,7 +34,8 @@ expect_equal(
     pl_iris,
     x = 1,
     x = 2,
-    x = NULL
+    x = NULL,
+    env = current_env()
   ),
   list(
     pool_exprs_1 = list(x = pl$lit(1)),
@@ -47,7 +49,8 @@ expect_equal(
     pl_iris,
     x = 1,
     x = "a",
-    x = NULL
+    x = NULL,
+    env = current_env()
   ),
   list(
     pool_exprs_1 = list(x = pl$lit(1)),

--- a/tests/tinytest/test_utils-expr_lazy.R
+++ b/tests/tinytest/test_utils-expr_lazy.R
@@ -16,7 +16,7 @@ expect_equal_lazy(
     x = NULL,
     mean_pl = mean(Petal.Length),
     foo = Sepal.Width + Petal.Width,
-    env = current_env()
+    env = rlang::current_env()
   ),
   list(
     pool_exprs_1 = list(
@@ -39,7 +39,7 @@ expect_equal_lazy(
     x = 1,
     x = 2,
     x = NULL,
-    env = current_env()
+    env = rlang::current_env()
   ),
   list(
     pool_exprs_1 = list(x = pl$lit(1)),
@@ -54,7 +54,7 @@ expect_equal_lazy(
     x = 1,
     x = "a",
     x = NULL,
-    env = current_env()
+    env = rlang::current_env()
   ),
   list(
     pool_exprs_1 = list(x = pl$lit(1)),

--- a/tests/tinytest/test_utils-expr_lazy.R
+++ b/tests/tinytest/test_utils-expr_lazy.R
@@ -15,7 +15,8 @@ expect_equal_lazy(
     Petal.Length = Petal.Length / x,
     x = NULL,
     mean_pl = mean(Petal.Length),
-    foo = Sepal.Width + Petal.Width
+    foo = Sepal.Width + Petal.Width,
+    env = current_env()
   ),
   list(
     pool_exprs_1 = list(
@@ -37,7 +38,8 @@ expect_equal_lazy(
     pl_iris,
     x = 1,
     x = 2,
-    x = NULL
+    x = NULL,
+    env = current_env()
   ),
   list(
     pool_exprs_1 = list(x = pl$lit(1)),
@@ -51,7 +53,8 @@ expect_equal_lazy(
     pl_iris,
     x = 1,
     x = "a",
-    x = NULL
+    x = NULL,
+    env = current_env()
   ),
   list(
     pool_exprs_1 = list(x = pl$lit(1)),


### PR DESCRIPTION
Problem: the expressions handling relies on translating each element as we go. For example, `ifelse(cond, yes, no)` requires translating `cond`, `yes` and `no`, and each of these components can take expressions.

Therefore, I need to pass the environment and the list of variables previously created in the same `mutate()` or `summarize()` to each translation.