### PR TITLE
Make `tidyselect` faster

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@
 * Error messages coming from `mutate()`, `summarize()`, and `filter()` now give 
   the right function call. 
 
+* Faster tidy selection (#61).
+
 # tidypolars (0.3.0)
 
 `tidypolars` requires `polars` >= 0.10.0.

--- a/README.Rmd
+++ b/README.Rmd
@@ -180,7 +180,7 @@ bench::mark(
       fsubset(Sepal.Length >= 4.5 & Sepal.Length <= 5.5)
   },
   check = FALSE,
-  iterations = 10
+  iterations = 20
 )
 
 # NOTE: do NOT take the "mem_alloc" results into account.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ benchmarks](https://duckdblabs.github.io/db-benchmark/).
 
 ``` r
 library(collapse, warn.conflicts = FALSE)
-#> collapse 2.0.2, see ?`collapse-package` or ?`collapse-documentation`
+#> collapse 2.0.3, see ?`collapse-package` or ?`collapse-documentation`
 
 large_iris <- data.table::rbindlist(rep(list(iris), 50000))
 large_iris_pl <- as_polars(large_iris, lazy = TRUE)
@@ -208,17 +208,17 @@ bench::mark(
       fsubset(Sepal.Length >= 4.5 & Sepal.Length <= 5.5)
   },
   check = FALSE,
-  iterations = 10
+  iterations = 20
 )
 #> Warning: Some expressions had a GC in every iteration; so filtering is
 #> disabled.
 #> # A tibble: 4 × 6
 #>   expression      min   median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-#> 1 polars     141.97ms  168.5ms     5.91     26.6KB     0   
-#> 2 tidypolars 162.03ms 207.92ms     4.90     74.6KB     0   
-#> 3 dplyr         3.29s    3.43s     0.288   916.6MB     1.30
-#> 4 collapse    278.9ms 390.28ms     2.53    373.1MB     2.27
+#> 1 polars     151.74ms 176.11ms     5.76     26.5KB    0    
+#> 2 tidypolars 179.46ms 216.24ms     4.05    284.4KB    0.203
+#> 3 dplyr         3.22s    3.92s     0.257   916.6MB    0.989
+#> 4 collapse   312.42ms 435.57ms     2.28    373.1MB    2.28
 
 # NOTE: do NOT take the "mem_alloc" results into account.
 # `bench::mark()` doesn't report the accurate memory usage for packages calling


### PR DESCRIPTION
Do not collect a 1-row slice but instead use the schema to create an empty DataFrame with the same columns and types, and use this in `tidyselect`. This shows performance improvements when we chain several functions, not just `select()`.

**Benchmark**

```r
large_iris <- data.table::rbindlist(rep(list(iris), 50000))
test <- as_polars(large_iris, lazy = TRUE)

bench::mark(
  starts_with = test |>
    select(starts_with(c("Sep", "Pet"))) |>
    mutate(
      petal_type = ifelse((Petal.Length / Petal.Width) > 3, "long", "large")
    ) |> 
    filter(between(Sepal.Length, 4.5, 5.5)) |> 
    collect(),
  iterations = 20,
  check = FALSE
) |> 
  dplyr::select(expression, 3:5)
``` 

**Before:**
```r
# A tibble: 1 × 4
  expression    median `itr/sec` mem_alloc
  <bch:expr>  <bch:tm>     <dbl> <bch:byt>
1 starts_with    495ms      1.59    1.05MB
```

**After:**
```r
# A tibble: 1 × 4
  expression    median `itr/sec` mem_alloc
  <bch:expr>  <bch:tm>     <dbl> <bch:byt>
1 starts_with    171ms      5.68     954KB
```
