### PR TITLE
Handle explicit namespace with `::` in expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,9 @@
   
   - from package `tidyr`: `replace_na()` (the data.frame method was already
     translated but not the vector one that can be used in `mutate()` for example).
+    
+* It is now possible to use explicit namespaces (such as `dplyr::first()` instead
+  of `first()`) in `mutate()`, `summarize()` and `filter()` (#114).
 
 ## Bug fixes
 

--- a/R/funs-date.R
+++ b/R/funs-date.R
@@ -3,7 +3,7 @@
 
 # Date/time parsing --------------------------------------
 
-pl_ymd <- function(x, ...) {
+pl_ymd_lubridate <- function(x, ...) {
   check_empty_dots(...)
   # I can't specify a particular format: lubridate::ymd() can detect "2009/01/01"
   # and "2009-01-01" for example. I have to rely on polars' guessing, even if
@@ -11,9 +11,9 @@ pl_ymd <- function(x, ...) {
   x$str$strptime(pl$Date, format = NULL, strict = FALSE)
 }
 
-pl_ydm <- pl_mdy<- pl_myd <- pl_dmy<- pl_dym <- pl_ym <- pl_my <- pl_ymd
+pl_ydm_lubridate <- pl_mdy_lubridate <- pl_myd_lubridate <- pl_dmy_lubridate <- pl_dym_lubridate <- pl_ym_lubridate <- pl_my_lubridate <- pl_ymd_lubridate
 
-pl_ymd_hms <- function(x, ...) {
+pl_ymd_hms_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$str$strptime(pl$Datetime("ms"), format = NULL, strict = FALSE)
 }
@@ -21,59 +21,59 @@ pl_ymd_hms <- function(x, ...) {
 
 # Setting/getting/rounding --------------------------------------
 
-pl_year <- function(x, ...) {
+pl_year_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$year()
 }
 
-pl_isoyear <- function(x, ...) {
+pl_isoyear_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$iso_year()
 }
 
-pl_quarter <- function(x, ...) {
+pl_quarter_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$quarter()
 }
 
-pl_month <- function(x, ...) {
+pl_month_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$month()
 }
 
-pl_week <- function(x, ...) {
+pl_week_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$week()
 }
 
-pl_day <- function(x, ...) {
+pl_day_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$day()
 }
 
 # TODO: doesn't work because lubridate's default is start counting from Sundays
 # (and has an option to change that)
-pl_wday <- function(x, ...) {
+pl_wday_lubridate <- function(x, ...) {
   x$dt$weekday()
 }
 
-pl_mday <- pl_day
+pl_mday_lubridate <- pl_day_lubridate
 
-pl_yday <- function(x, ...) {
+pl_yday_lubridate <- function(x, ...) {
   x$dt$ordinal_day()
 }
 
-pl_hour <- function(x, ...) {
+pl_hour_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$hour()
 }
 
-pl_minute <- function(x, ...) {
+pl_minute_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$minute()
 }
 
-pl_second <- function(x, ...) {
+pl_second_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$second()
 }
@@ -90,43 +90,43 @@ pl_second <- function(x, ...) {
 #   pl$duration(weeks = x)
 # }
 
-pl_dweeks <- function(x, ...) {
+pl_dweeks_lubridate <- function(x, ...) {
   pl$duration(weeks = x)
 }
 
-pl_ddays <- function(x, ...) {
+pl_ddays_lubridate <- function(x, ...) {
   pl$duration(days = x)
 }
 
-pl_dhours <- function(x, ...) {
+pl_dhours_lubridate <- function(x, ...) {
   pl$duration(hours = x)
 }
 
-pl_dminutes <- function(x, ...) {
+pl_dminutes_lubridate <- function(x, ...) {
   pl$duration(minutes = x)
 }
 
-pl_dseconds <- function(x, ...) {
+pl_dseconds_lubridate <- function(x, ...) {
   pl$duration(seconds = x)
 }
 
-pl_dmilliseconds <- function(x, ...) {
+pl_dmilliseconds_lubridate <- function(x, ...) {
   pl$duration(milliseconds = x)
 }
 
-pl_dmicroseconds <- function(x, ...) {
+pl_dmicroseconds_lubridate <- function(x, ...) {
   pl$duration(microseconds = x)
 }
 
-pl_dnanoseconds <- function(x, ...) {
+pl_dnanoseconds_lubridate <- function(x, ...) {
   pl$duration(nanoseconds = x)
 }
 
-pl_make_date <- function(year = 1970, month = 1, day = 1) {
+pl_make_date_lubridate <- function(year = 1970, month = 1, day = 1) {
   pl$date(year = year, month = month, day = day)
 }
 
-pl_make_datetime <- function(
+pl_make_datetime_lubridate <- function(
     year = 1970,
     month = 1,
     day = 1,
@@ -180,78 +180,48 @@ pl_ISOdatetime <- function(
 
 # OLD IMPLEMENTATIONS
 
-
-
-
-pl_default_round <- function(x, ...) {
-  check_empty_dots(...)
-  x$default$round()
-}
-
-pl_epoch <- function(x, ...) {
-  check_empty_dots(...)
-  x$dt$epoch()
-}
-
-
-pl_hours <- function(x, ...) {
+pl_hours_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$hours()
 }
 
-pl_microsecond <- function(x, ...) {
+pl_microsecond_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$microsecond()
 }
 
-pl_microseconds <- function(x, ...) {
+pl_microseconds_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$microseconds()
 }
 
-pl_millisecond <- function(x, ...) {
+pl_millisecond_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$millisecond()
 }
 
-pl_milliseconds <- function(x, ...) {
+pl_milliseconds_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$milliseconds()
 }
 
-pl_minutes <- function(x, ...) {
+pl_minutes_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$minutes()
 }
 
 
-pl_nanosecond <- function(x, ...) {
+pl_nanosecond_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$nanosecond()
 }
 
-pl_nanoseconds <- function(x, ...) {
+pl_nanoseconds_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$nanoseconds()
 }
 
-pl_offset_by <- function(x, ...) {
-  check_empty_dots(...)
-  x$dt$offset_by()
-}
-
-pl_ordinal_day <- function(x, ...) {
-  check_empty_dots(...)
-  x$dt$ordinal_day()
-}
-
-
-pl_replace_time_zone <- function(x, ...) {
-  check_empty_dots(...)
-  x$dt$replace_time_zone()
-}
-
-pl_seconds <- function(x, ...) {
+pl_seconds_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$seconds()
 }
@@ -289,14 +259,7 @@ pl_tz_localize <- function(x, ...) {
 
 # TODO: check the day of weekstart (lubridate starts the
 # week on sunday, polars on monday)
-pl_weekday <- function(x, ...) {
+pl_weekday_lubridate <- function(x, ...) {
   check_empty_dots(...)
   x$dt$weekday()
 }
-
-pl_with_time_unit <- function(x, ...) {
-  check_empty_dots(...)
-  x$dt$with_time_unit()
-}
-
-

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -148,22 +148,7 @@ pl_atanh <- function(x, ...) {
   x$arctanh()
 }
 
-pl_which.max <- function(x, ...) {
-  check_empty_dots(...)
-  x$arg_max() + 1
-}
-
-pl_which.min <- function(x, ...) {
-  check_empty_dots(...)
-  x$arg_min() + 1
-}
-
-pl_arg_sort <- function(x, ...) {
-  check_empty_dots(...)
-  x$arg_sort()
-}
-
-pl_between <- function(x, left, right, ...) {
+pl_between_dplyr <- function(x, left, right, ...) {
   check_empty_dots(...)
   x$is_between(lower_bound = left, upper_bound = right, closed = "both")
 }
@@ -231,12 +216,12 @@ pl_ceiling <- function(x, ...) {
   x$ceil()
 }
 
-pl_coalesce <- function(..., default = NULL) {
+pl_coalesce_dplyr <- function(..., default = NULL) {
   # pl$coalesce() doesn't accept a list
   call2(pl$coalesce, !!!clean_dots(...), default) |> eval_bare()
 }
 
-pl_consecutive_id <- function(...) {
+pl_consecutive_id_dplyr <- function(...) {
   dots <- clean_dots(...)
   env <- env_from_dots(...)
   if (length(dots) == 0) {
@@ -279,11 +264,6 @@ pl_cumsum <- function(x, ...) {
   x$cum_sum()
 }
 
-pl_cumulative_eval <- function(x, ...) {
-  check_empty_dots(...)
-  x$cumulative_eval()
-}
-
 pl_diff <- function(x, lag = 1, differences = 1, ...) {
   check_empty_dots(...)
   if (!is.null(differences) && length(differences) == 1 && differences != 1) {
@@ -305,7 +285,7 @@ pl_exp <- function(x, ...) {
   x$exp()
 }
 
-pl_first <- function(x, ...) {
+pl_first_dplyr <- function(x, ...) {
   check_empty_dots(...)
   x$first()
 }
@@ -329,11 +309,6 @@ pl_infinite <- function(x, ...) {
 pl_interpolate <- function(x, ...) {
   check_empty_dots(...)
   x$interpolate()
-}
-
-pl_is_duplicated <- function(x, ...) {
-  check_empty_dots(...)
-  x$is_duplicated()
 }
 
 pl_is.finite <- function(x, ...) {
@@ -361,22 +336,22 @@ pl_is.null <- function(x, ...) {
   x$is_null()
 }
 
-pl_is_unique <- function(x, ...) {
-  check_empty_dots(...)
-  x$is_unique()
-}
-
-pl_bottom_k <- function(x, ...) {
-  check_empty_dots(...)
-  x$bottom_k()
-}
-
 pl_kurtosis <- function(x, ...) {
   check_empty_dots(...)
   x$kurtosis()
 }
 
-pl_last <- function(x, ...) {
+pl_lag <- function(x, k = 1, ...) {
+  check_empty_dots(...)
+  x$shift(k)
+}
+
+pl_lag_dplyr <- function(x, n = 1, ...) {
+  check_empty_dots(...)
+  x$shift(n)
+}
+
+pl_last_dplyr <- function(x, ...) {
   check_empty_dots(...)
   x$last()
 }
@@ -400,31 +375,16 @@ pl_mode <- function(x, ...) {
   x$mode()
 }
 
-pl_fill_nan <- function(x, ...) {
-  check_empty_dots(...)
-  x$fill_nan()
-}
-
-pl_drop_nans <- function(x, ...) {
-  check_empty_dots(...)
-  x$drop_nans()
-}
-
-pl_fill_null <- function(x, ...) {
-  check_empty_dots(...)
-  x$fill_null()
-}
-
-pl_drop_nulls <- function(x, ...) {
-  check_empty_dots(...)
-  x$drop_nulls()
-}
-
-pl_min_rank <- function(x) {
+pl_min_rank_dplyr <- function(x) {
   x$rank(method = "min")
 }
 
-pl_na_if <- function(x, y) {
+pl_n_dplyr <- function(...) {
+  check_empty_dots()
+  pl$len()
+}
+
+pl_na_if_dplyr <- function(x, y) {
   if (length(y) == 1 && !inherits(y, "RPolarsExpr") && is.na(y)) {
     pl$when(x$is_null())$then(pl$lit(NA))$otherwise(x)
   } else {
@@ -432,7 +392,7 @@ pl_na_if <- function(x, y) {
   }
 }
 
-pl_n_distinct <- function(..., na.rm = FALSE) {
+pl_n_distinct_dplyr <- function(..., na.rm = FALSE) {
   dots <- clean_dots(...)
   if (length(dots) == 0) {
     abort(
@@ -448,7 +408,7 @@ pl_n_distinct <- function(..., na.rm = FALSE) {
   }
 }
 
-pl_nth <- function(x, n, ...) {
+pl_nth_dplyr <- function(x, n, ...) {
   if (length(n) > 1) {
     abort(
       paste0("`n` must have size 1, not size ", length(n), "."),
@@ -474,16 +434,12 @@ pl_nth <- function(x, n, ...) {
   x$gather(n)
 }
 
-pl_quantile <- function(x, ...) {
-  check_empty_dots(...)
-  x$quantile()
-}
 pl_rank <- function(x, ...) {
   check_empty_dots(...)
   x$rank()
 }
 
-pl_replace_na <- function(data, replace, ...) {
+pl_replace_na_tidyr <- function(data, replace, ...) {
   check_empty_dots(...)
   data$fill_null(replace)
 }
@@ -493,16 +449,14 @@ pl_round <- function(x, digits = 0, ...) {
   x$round(decimals = digits)
 }
 
+pl_rev <- function(x) {
+  x$reverse()
+}
+
 pl_sample <- function(x, size = NULL, replace = FALSE, ...) {
   check_empty_dots(...)
   # TODO: how should I handle seed, given that R sample() doesn't have this arg
   x$sample(n = size, with_replacement = replace, shuffle = TRUE)
-}
-
-pl_lag <- function(x, n = 1, k = NULL, ...) {
-  check_empty_dots(...)
-  if (!is.null(k)) n <- k
-  x$shift(n)
 }
 
 pl_sign <- function(x, ...) {
@@ -523,11 +477,6 @@ pl_sinh <- function(x, ...) {
 pl_skew <- function(x, ...) {
   check_empty_dots(...)
   x$skew()
-}
-
-pl_slice <- function(x, ...) {
-  check_empty_dots(...)
-  x$slice()
 }
 
 pl_sort <- function(x, ...) {
@@ -565,106 +514,12 @@ pl_var <- function(x, ddof = 1, ...) {
   x$var(ddof = ddof)
 }
 
-pl_n_unique <- function(x, ...) {
+pl_which.max <- function(x, ...) {
   check_empty_dots(...)
-  x$n_unique()
+  x$arg_max() + 1
 }
 
-pl_nan_max <- function(x, ...) {
+pl_which.min <- function(x, ...) {
   check_empty_dots(...)
-  x$nan_max()
-}
-
-pl_nan_min <- function(x, ...) {
-  check_empty_dots(...)
-  x$nan_min()
-}
-
-pl_null_count <- function(x, ...) {
-  check_empty_dots(...)
-  x$null_count()
-}
-
-pl_pct_change <- function(x, ...) {
-  check_empty_dots(...)
-  x$pct_change()
-}
-
-pl_rev <- function(x) {
-  x$reverse()
-}
-
-pl_rolling_max <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_max()
-}
-
-pl_rolling_mean <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_mean()
-}
-
-pl_rolling_median <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_median()
-}
-
-pl_rolling_min <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_min()
-}
-
-pl_rolling_quantile <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_quantile()
-}
-
-pl_rolling_skew <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_skew()
-}
-
-pl_rolling_std <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_std()
-}
-
-pl_rolling_sum <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_sum()
-}
-
-pl_rolling_var <- function(x, ...) {
-  check_empty_dots(...)
-  x$rolling_var()
-}
-
-pl_shift_and_fill <- function(x, ...) {
-  check_empty_dots(...)
-  x$shift_and_fill()
-}
-
-pl_top_k <- function(x, ...) {
-  check_empty_dots(...)
-  x$top_k()
-}
-
-pl_unique_counts <- function(x, ...) {
-  check_empty_dots(...)
-  x$unique_counts()
-}
-
-pl_upper_lower_bound <- function(x, ...) {
-  check_empty_dots(...)
-  x$upper_lower_bound()
-}
-
-pl_value_counts <- function(x, ...) {
-  check_empty_dots(...)
-  x$value_counts()
-}
-
-pl_n <- function(...) {
-  check_empty_dots()
-  pl$len()
+  x$arg_min() + 1
 }

--- a/R/funs-string.R
+++ b/R/funs-string.R
@@ -2,7 +2,7 @@ pl_grepl <- function(pattern, x, fixed = FALSE, ...) {
   if (isTRUE(fixed)) {
     attr(x, "stringr_attr") <- "fixed"
   }
-  pl_str_detect(string = x, pattern = pattern, ...)
+  pl_str_detect_stringr(string = x, pattern = pattern, ...)
 }
 
 pl_paste0 <- function(..., collapse = NULL) {
@@ -14,13 +14,13 @@ pl_paste <- function(..., sep = " ", collapse = NULL) {
   call2(pl$concat_str, !!!clean_dots(...), separator = sep) |> eval_bare()
 }
 
-pl_str_count <- function(string, pattern = "", ...) {
+pl_str_count_stringr <- function(string, pattern = "", ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
   string$str$count_matches(pattern$pattern, literal = pattern$is_fixed)
 }
 
-pl_str_detect <- function(string, pattern, negate = FALSE, ...) {
+pl_str_detect_stringr <- function(string, pattern, negate = FALSE, ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
   out <- string$str$contains(pattern$pattern, literal = pattern$is_fixed)
@@ -31,7 +31,7 @@ pl_str_detect <- function(string, pattern, negate = FALSE, ...) {
   }
 }
 
-pl_str_dup <- function(string, times) {
+pl_str_dup_stringr <- function(string, times) {
   if (inherits(times, "RPolarsExpr")) {
     return(string$repeat_by(times)$list$join(""))
   } else if (is.na(times) || times < 0) {
@@ -42,7 +42,7 @@ pl_str_dup <- function(string, times) {
   call2(pl$concat_str, !!!rep(list(string), times)) |> eval_bare()
 }
 
-pl_str_ends <- function(string, pattern, negate = FALSE, ...) {
+pl_str_ends_stringr <- function(string, pattern, negate = FALSE, ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
 
@@ -61,7 +61,7 @@ pl_str_ends <- function(string, pattern, negate = FALSE, ...) {
 }
 
 # group = 0 means the whole match
-pl_str_extract <- function(string, pattern, group = 0, ...) {
+pl_str_extract_stringr <- function(string, pattern, group = 0, ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
   # if pattern wasn't passed to pl$col() at this point then it must be parsed
@@ -76,20 +76,20 @@ pl_str_extract <- function(string, pattern, group = 0, ...) {
 # TODO: argument "simplify" should be allowed. It requires the method "unnest"
 # for "struct". When it is implement in r-polars, use this:
 # $list$to_struct()$struct$unnest()
-pl_str_extract_all <- function(string, pattern, ...) {
+pl_str_extract_all_stringr <- function(string, pattern, ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
   string$str$extract_all(pattern$pattern)
 }
 
-pl_str_length <- function(string, ...) {
+pl_str_length_stringr <- function(string, ...) {
   check_empty_dots(...)
   string$str$len_chars()
 }
 
-pl_nchar <- pl_str_length
+pl_nchar <- pl_str_length_stringr
 
-pl_str_pad <- function(string, width, side = "left", pad = " ", use_width = TRUE, ...) {
+pl_str_pad_stringr <- function(string, width, side = "left", pad = " ", use_width = TRUE, ...) {
   check_empty_dots(...)
   if (isFALSE(use_width)) {
     abort(
@@ -109,19 +109,19 @@ pl_str_pad <- function(string, width, side = "left", pad = " ", use_width = TRUE
   )
 }
 
-pl_str_remove <- function(string, pattern, ...) {
+pl_str_remove_stringr <- function(string, pattern, ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
   string$str$replace(pattern$pattern, "")
 }
 
-pl_str_remove_all <- function(string, pattern, ...) {
+pl_str_remove_all_stringr <- function(string, pattern, ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
   string$str$replace_all(pattern$pattern, "")
 }
 
-pl_str_replace <- function(string, pattern, replacement, ...) {
+pl_str_replace_stringr <- function(string, pattern, replacement, ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
   if (is.character(replacement)) {
@@ -130,7 +130,7 @@ pl_str_replace <- function(string, pattern, replacement, ...) {
   string$str$replace(pattern$pattern, replacement)
 }
 
-pl_str_replace_all <- function(string, pattern, replacement, ...) {
+pl_str_replace_all_stringr <- function(string, pattern, replacement, ...) {
   check_empty_dots(...)
   # named pattern means that names are patterns and values are replacements
   names_pattern <- names(pattern)
@@ -149,12 +149,12 @@ pl_str_replace_all <- function(string, pattern, replacement, ...) {
   out
 }
 
-pl_str_squish <- function(string, ...) {
+pl_str_squish_stringr <- function(string, ...) {
   check_empty_dots(...)
   string$str$replace_all("\\s+", " ")$str$strip_chars()
 }
 
-pl_str_starts <- function(string, pattern, negate = FALSE, ...) {
+pl_str_starts_stringr <- function(string, pattern, negate = FALSE, ...) {
   check_empty_dots(...)
   pattern <- check_pattern(pattern)
 
@@ -172,7 +172,7 @@ pl_str_starts <- function(string, pattern, negate = FALSE, ...) {
   out
 }
 
-pl_str_sub <- function(string, start, end = NULL, ...) {
+pl_str_sub_stringr <- function(string, start, end = NULL, ...) {
   check_empty_dots(...)
   # polars is 0-indexed
   if (start > 0) start <- start - 1
@@ -185,12 +185,12 @@ pl_str_sub <- function(string, start, end = NULL, ...) {
 #
 # Expresses the same objective as me:
 # https://github.com/pola-rs/polars/issues/13649
-pl_str_split <- function(string, pattern, ...) {
+pl_str_split_stringr <- function(string, pattern, ...) {
   check_empty_dots(...)
   string$str$split(by = pattern, inclusive = FALSE)
 }
 
-pl_str_split_i <- function(string, pattern, i, ...) {
+pl_str_split_i_stringr <- function(string, pattern, i, ...) {
   check_empty_dots(...)
   if (i == 0) {
     abort("`i` must not be 0.", call = env_from_dots(...))
@@ -200,26 +200,26 @@ pl_str_split_i <- function(string, pattern, i, ...) {
   string$str$split(by = pattern, inclusive = FALSE)$list$get(i, null_on_oob = TRUE)
 }
 
-pl_str_to_lower <- function(string, ...) {
+pl_str_to_lower_stringr <- function(string, ...) {
   check_empty_dots(...)
   string$str$to_lowercase()
 }
-pl_tolower <- pl_str_to_lower
+pl_tolower <- pl_str_to_lower_stringr
 
-pl_str_to_upper <- function(string, ...) {
+pl_str_to_upper_stringr <- function(string, ...) {
   check_empty_dots(...)
   string$str$to_uppercase()
 }
-pl_toupper <- pl_str_to_upper
+pl_toupper <- pl_str_to_upper_stringr
 
 
-pl_str_to_title <- function(string, ...) {
+pl_str_to_title_stringr <- function(string, ...) {
   check_empty_dots(...)
   string$str$to_titlecase()
 }
-pl_toTitleCase <- pl_str_to_title
+pl_toTitleCase <- pl_str_to_title_stringr
 
-pl_str_trim <- function(string, side = "both", ...) {
+pl_str_trim_stringr <- function(string, side = "both", ...) {
   check_empty_dots(...)
   switch(
     side,
@@ -231,10 +231,10 @@ pl_str_trim <- function(string, side = "both", ...) {
 
 pl_trimws <- function(string, which = "both", ...) {
   check_empty_dots(...)
-  pl_str_trim(string, side = which)
+  pl_str_trim_stringr(string, side = which)
 }
 
-pl_word <- function(string, start = 1L, end = start, sep = " ", ...) {
+pl_word_stringr <- function(string, start = 1L, end = start, sep = " ", ...) {
   check_empty_dots(...)
   string$str$split(sep)$list$gather((start:end) - 1L)$list$join(sep)
 }

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -610,20 +610,20 @@ add_pkg_suffix <- function(name, known_ops, user_defined) {
   if (name %in% c(known_ops, user_defined)) {
     return(list(orig_name = name, name_to_eval = name))
   }
-  pkg <- tryCatch(
-    ns_env_name(as_function(name)),
-    error = function(e) {
-      if (grepl("::", name)) {
-        return(gsub(".*::", "", name))
-      } else {
-        return(NULL)
-      }
-    }
-  )
-  if (is.null(pkg) || pkg %in% c("base", "stats", "utils", "tools")) {
-    name_to_eval <- paste0("pl_", name)
+  fn <- name
+  pkg <- if (grepl("::", name)) {
+    fn <- gsub(".*::", "", name)
+    gsub("::.*", "", name)
   } else {
-    name_to_eval <- paste0("pl_", name, "_", pkg)
+    tryCatch(
+      ns_env_name(as_function(name)),
+      error = function(e) return(NULL)
+    )
+  }
+  if (is.null(pkg) || pkg %in% c("base", "stats", "utils", "tools")) {
+    name_to_eval <- paste0("pl_", fn)
+  } else {
+    name_to_eval <- paste0("pl_", fn, "_", pkg)
   }
   list(orig_name = name, name_to_eval = name_to_eval)
 }

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -511,7 +511,7 @@ translate <- function(
             orig_name <- gsub("^pl_", "", name)
             abort(
               c(
-                paste0("Couldn't evaluate function `", orig_name, "()` in Polars."),
+                paste0("Error while running function `", orig_name, "()` in Polars."),
                 "x" = toupper_first(conditionMessage(e))
               ),
               call = env

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -429,7 +429,10 @@ translate <- function(
       is_known <- is_function_known(name)
 
       if (!missing(env) && isTRUE(env$is_rowwise)) {
-        shortlist <- c("mean", "median", "min", "max", "sum", "all", "any", "!")
+        shortlist <- c(
+          paste0("pl_", c("mean", "median", "min", "max", "sum", "all", "any")),
+          "!"
+        )
         if (!name %in% shortlist) {
           rlang::abort(
             c(

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -611,20 +611,22 @@ add_pkg_suffix <- function(name, known_ops, user_defined) {
     return(list(orig_name = name, name_to_eval = name))
   }
 
-  if (grepl("::", name)) {
-    pkg <- gsub("::.*", "", name)
-    name <- gsub(".*::", "", name)
+  fn <- name
+
+  if (grepl("::", fn)) {
+    pkg <- gsub("::.*", "", fn)
+    fn <- gsub(".*::", "", fn)
   } else {
     pkg <- tryCatch(
-      getNamespaceName(environment(eval(parse(text = name)))),
+      ns_env_name(as_function(name)),
       error = function(e) return(NULL)
     )
   }
 
   if (is.null(pkg) || pkg %in% c("base", "stats", "utils", "tools")) {
-    name_to_eval <- paste0("pl_", name)
+    name_to_eval <- paste0("pl_", fn)
   } else {
-    name_to_eval <- paste0("pl_", name, "_", pkg)
+    name_to_eval <- paste0("pl_", fn, "_", pkg)
   }
   list(orig_name = name, name_to_eval = name_to_eval)
 }

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -616,7 +616,7 @@ add_pkg_suffix <- function(name, known_ops, user_defined) {
     gsub("::.*", "", name)
   } else {
     tryCatch(
-      ns_env_name(as_function(name)),
+      getNamespaceName(environment(eval(parse(text = name)))),
       error = function(e) return(NULL)
     )
   }

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -610,20 +610,21 @@ add_pkg_suffix <- function(name, known_ops, user_defined) {
   if (name %in% c(known_ops, user_defined)) {
     return(list(orig_name = name, name_to_eval = name))
   }
-  fn <- name
-  pkg <- if (grepl("::", name)) {
-    fn <- gsub(".*::", "", name)
-    gsub("::.*", "", name)
+
+  if (grepl("::", name)) {
+    pkg <- gsub("::.*", "", name)
+    name <- gsub(".*::", "", name)
   } else {
-    tryCatch(
+    pkg <- tryCatch(
       getNamespaceName(environment(eval(parse(text = name)))),
       error = function(e) return(NULL)
     )
   }
+
   if (is.null(pkg) || pkg %in% c("base", "stats", "utils", "tools")) {
-    name_to_eval <- paste0("pl_", fn)
+    name_to_eval <- paste0("pl_", name)
   } else {
-    name_to_eval <- paste0("pl_", fn, "_", pkg)
+    name_to_eval <- paste0("pl_", name, "_", pkg)
   }
   list(orig_name = name, name_to_eval = name_to_eval)
 }

--- a/tests/tinytest/test_explicit_namespace.R
+++ b/tests/tinytest/test_explicit_namespace.R
@@ -8,6 +8,11 @@ expect_equal(
   test |> mutate(y = dplyr::lag(x))
 )
 
+expect_equal(
+  test |> mutate(y = sum(x)),
+  test |> mutate(y = base::sum(x))
+)
+
 # function exists but has no translation
 expect_error(
   test |> mutate(y = data.table::shift(x)),

--- a/tests/tinytest/test_explicit_namespace.R
+++ b/tests/tinytest/test_explicit_namespace.R
@@ -1,0 +1,15 @@
+source("helpers.R")
+using("tidypolars")
+
+test <- polars::pl$DataFrame(x = 1:3)
+
+expect_equal(
+  test |> mutate(y = lag(x)),
+  test |> mutate(y = dplyr::lag(x))
+)
+
+# function exists but has no translation
+expect_error(
+  test |> mutate(y = data.table::shift(x)),
+  "doesn't know how to translate this function"
+)

--- a/tests/tinytest/test_explicit_namespace.R
+++ b/tests/tinytest/test_explicit_namespace.R
@@ -3,14 +3,26 @@ using("tidypolars")
 
 test <- polars::pl$DataFrame(x = 1:3)
 
+# with base
+expect_equal(
+  test |> mutate(y = sum(x)),
+  test |> mutate(y = base::sum(x))
+)
+
+# with other pkgs
 expect_equal(
   test |> mutate(y = lag(x)),
   test |> mutate(y = dplyr::lag(x))
 )
 
 expect_equal(
-  test |> mutate(y = sum(x)),
-  test |> mutate(y = base::sum(x))
+  test |> summarize(y = lag(x)),
+  test |> summarize(y = dplyr::lag(x))
+)
+
+expect_equal(
+  test |> filter(x == first(x)),
+  test |> filter(x == dplyr::first(x))
 )
 
 # function exists but has no translation

--- a/tests/tinytest/test_explicit_namespace.R
+++ b/tests/tinytest/test_explicit_namespace.R
@@ -16,5 +16,5 @@ expect_equal(
 # function exists but has no translation
 expect_error(
   test |> mutate(y = data.table::shift(x)),
-  "doesn't know how to translate this function"
+  "doesn't know how to translate this function: `data.table::shift\\(\\)"
 )

--- a/tests/tinytest/test_explicit_namespace_lazy.R
+++ b/tests/tinytest/test_explicit_namespace_lazy.R
@@ -7,14 +7,26 @@ using("tidypolars")
 
 test <- polars::pl$LazyFrame(x = 1:3)
 
+# with base
+expect_equal_lazy(
+  test |> mutate(y = sum(x)),
+  test |> mutate(y = base::sum(x))
+)
+
+# with other pkgs
 expect_equal_lazy(
   test |> mutate(y = lag(x)),
   test |> mutate(y = dplyr::lag(x))
 )
 
 expect_equal_lazy(
-  test |> mutate(y = sum(x)),
-  test |> mutate(y = base::sum(x))
+  test |> summarize(y = lag(x)),
+  test |> summarize(y = dplyr::lag(x))
+)
+
+expect_equal_lazy(
+  test |> filter(x == first(x)),
+  test |> filter(x == dplyr::first(x))
 )
 
 # function exists but has no translation

--- a/tests/tinytest/test_explicit_namespace_lazy.R
+++ b/tests/tinytest/test_explicit_namespace_lazy.R
@@ -12,6 +12,11 @@ expect_equal_lazy(
   test |> mutate(y = dplyr::lag(x))
 )
 
+expect_equal_lazy(
+  test |> mutate(y = sum(x)),
+  test |> mutate(y = base::sum(x))
+)
+
 # function exists but has no translation
 expect_error_lazy(
   test |> mutate(y = data.table::shift(x)),

--- a/tests/tinytest/test_explicit_namespace_lazy.R
+++ b/tests/tinytest/test_explicit_namespace_lazy.R
@@ -1,0 +1,21 @@
+### [GENERATED AUTOMATICALLY] Update test_explicit_namespace.R instead.
+
+Sys.setenv('TIDYPOLARS_TEST' = TRUE)
+
+source("helpers.R")
+using("tidypolars")
+
+test <- polars::pl$LazyFrame(x = 1:3)
+
+expect_equal_lazy(
+  test |> mutate(y = lag(x)),
+  test |> mutate(y = dplyr::lag(x))
+)
+
+# function exists but has no translation
+expect_error_lazy(
+  test |> mutate(y = data.table::shift(x)),
+  "doesn't know how to translate this function"
+)
+
+Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/tinytest/test_explicit_namespace_lazy.R
+++ b/tests/tinytest/test_explicit_namespace_lazy.R
@@ -20,7 +20,7 @@ expect_equal_lazy(
 # function exists but has no translation
 expect_error_lazy(
   test |> mutate(y = data.table::shift(x)),
-  "doesn't know how to translate this function"
+  "doesn't know how to translate this function: `data.table::shift\\(\\)"
 )
 
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/tinytest/test_mutate.R
+++ b/tests/tinytest/test_mutate.R
@@ -250,7 +250,7 @@ foo2 <<- function(x, y) {
 
 expect_error(
   mutate(pl_iris, x = foo2(Sepal.Length, Petal.Length)),
-  "Couldn't evaluate function `foo2\\(\\)`"
+  "Error while running function `foo2\\(\\)`"
 )
 
 # embracing works

--- a/tests/tinytest/test_mutate_lazy.R
+++ b/tests/tinytest/test_mutate_lazy.R
@@ -254,7 +254,7 @@ foo2 <<- function(x, y) {
 
 expect_error_lazy(
   mutate(pl_iris, x = foo2(Sepal.Length, Petal.Length)),
-  "Couldn't evaluate function `foo2\\(\\)`"
+  "Error while running function `foo2\\(\\)`"
 )
 
 # embracing works

--- a/tests/tinytest/test_utils-expr.R
+++ b/tests/tinytest/test_utils-expr.R
@@ -58,8 +58,3 @@ expect_equal(
     pool_exprs_3 = list(x = NULL)
   )
 )
-
-expect_error(
-  mutate(pl_iris, Sepal.Length = dplyr::lag(Sepal.Length)),
-  "doesn't work when expressions contain"
-)

--- a/tests/tinytest/test_utils-expr_lazy.R
+++ b/tests/tinytest/test_utils-expr_lazy.R
@@ -63,9 +63,4 @@ expect_equal_lazy(
   )
 )
 
-expect_error_lazy(
-  mutate(pl_iris, Sepal.Length = dplyr::lag(Sepal.Length)),
-  "doesn't work when expressions contain"
-)
-
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)


### PR DESCRIPTION
Close #113

Also better error message when a function is unknown:

``` r
library(dplyr, warn.conflicts = FALSE)
library(tidypolars)

dat <- tibble(x = 1:3) |> as_polars_df()

dat |> 
  mutate(y = frank(x))
#> Error in `mutate()`:
#> ! `tidypolars` doesn't know how to translate this function: `frank()`

dat |> 
  mutate(y = data.table::frank(x))
#> Error in `mutate()`:
#> ! `tidypolars` doesn't know how to translate this function: `data.table::frank()`

library(data.table, warn.conflicts = FALSE)

dat |> 
  mutate(y = frank(x))
#> Error in `mutate()`:
#> ! `tidypolars` doesn't know how to translate this function: `frank()`
```
