### PR TITLE
feat: Better support for `dplyr` lead and lag

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
   supported for now (#149).
 
 * Added support for `dplyr::lead()`. In `dplyr::lead()` and `dplyr::lag()`, the 
-  argument `order_by` is now supported.
+  arguments `default` and `order_by` are now supported (#151).
 
 # tidypolars 0.11.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
 * Add support for argument `.groups` in `summarize()`. Value `"rowwise"` is not
   supported for now (#149).
 
+* Added support for `dplyr::lead()`. In `dplyr::lead()` and `dplyr::lag()`, the 
+  argument `order_by` is now supported.
+
 # tidypolars 0.11.0
 
 `tidypolars` requires `polars` >= 0.20.0.

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -584,11 +584,6 @@ pl_nth_dplyr <- function(x, n, ...) {
   x$gather(n)
 }
 
-pl_quantile <- function(x, probs, ...) {
-  check_empty_dots(...)
-  x$quantile(probs, interpolation = "midpoint")
-}
-
 pl_rank <- function(x, ...) {
   check_empty_dots(...)
   x$rank()

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -481,9 +481,13 @@ pl_kurtosis <- function(x, ...) {
   x$kurtosis()
 }
 
-pl_lag_dplyr <- function(x, n = 1, order_by = NULL, ...) {
+pl_lag_dplyr <- function(x, n = 1, default = NULL, order_by = NULL, ...) {
   check_empty_dots(...)
-  out <- x$shift(n)
+  if (!is.null(default)) {
+    out <- x$shift(n, fill_value = default)
+  } else {
+    out <- x$shift(n)
+  }
   if (!is.null(order_by)) {
     attr(out, "order_by") <- order_by
   }
@@ -495,9 +499,13 @@ pl_last_dplyr <- function(x, ...) {
   x$last()
 }
 
-pl_lead_dplyr <- function(x, n = 1, order_by = NULL, ...) {
+pl_lead_dplyr <- function(x, n = 1, default = NULL, order_by = NULL, ...) {
   check_empty_dots(...)
-  out <- x$shift(-n)
+  if (!is.null(default)) {
+    out <- x$shift(-n, fill_value = default)
+  } else {
+    out <- x$shift(-n)
+  }
   if (!is.null(order_by)) {
     attr(out, "order_by") <- order_by
   }

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -67,7 +67,7 @@ pl_mean <- function(x, na.rm = FALSE, ...) {
         pl$when(pl$element()$has_nulls())$
           then(NA)$
           otherwise(pl$element()$mean())
-        )$
+      )$
         explode()
     }
   } else {
@@ -481,26 +481,27 @@ pl_kurtosis <- function(x, ...) {
   x$kurtosis()
 }
 
-pl_lag <- function(x, k = 1, ...) {
+pl_lag_dplyr <- function(x, n = 1, order_by = NULL, ...) {
   check_empty_dots(...)
-  x$shift(k)
-}
-
-pl_lag_dplyr <- function(x, n = 1, ...) {
-  check_empty_dots(...)
-  # if (is.null(order_by)) {
-    x$shift(n)
-  # } else {
-  #   # Need to have at least one group so use 1 to use all data
-  #   # Requires: https://github.com/pola-rs/polars/issues/12051
-  #   x$shift(n)$over(1, order_by = order_by)
-  # }
-
+  out <- x$shift(n)
+  if (!is.null(order_by)) {
+    attr(out, "order_by") <- order_by
+  }
+  out
 }
 
 pl_last_dplyr <- function(x, ...) {
   check_empty_dots(...)
   x$last()
+}
+
+pl_lead_dplyr <- function(x, n = 1, order_by = NULL, ...) {
+  check_empty_dots(...)
+  out <- x$shift(-n)
+  if (!is.null(order_by)) {
+    attr(out, "order_by") <- order_by
+  }
+  out
 }
 
 pl_length <- function(x) {
@@ -581,6 +582,11 @@ pl_nth_dplyr <- function(x, n, ...) {
     n <- n - 1
   }
   x$gather(n)
+}
+
+pl_quantile <- function(x, probs, ...) {
+  check_empty_dots(...)
+  x$quantile(probs, interpolation = "midpoint")
 }
 
 pl_rank <- function(x, ...) {

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -54,7 +54,7 @@
 #' mutate(pl_iris, x = Sepal.Width > Sepal.Length & Petal.Width > Petal.Length)
 #'
 #' # overwrite existing variable
-#' mutate(pl_iris, Sepal.Width = Sepal.Width*2)
+#' mutate(pl_iris, Sepal.Width = Sepal.Width * 2)
 #'
 #' # grouped computation
 #' pl_iris |>
@@ -70,7 +70,7 @@
 #'   mutate(
 #'     across(.cols = contains("Sepal"), .fns = mean, .names = "{.fn}_of_{.col}")
 #'   )
-#
+#' #
 #' # It can receive several types of functions:
 #' pl_iris |>
 #'   mutate(
@@ -89,7 +89,7 @@
 #'     foo = 1,
 #'     across(
 #'       .cols = where(is.numeric),
-#'       \(x) x - 1000   # <<<<<<<<< this will not be applied on variable "foo"
+#'       \(x) x - 1000 # <<<<<<<<< this will not be applied on variable "foo"
 #'     )
 #'   )
 #' }
@@ -100,14 +100,11 @@
 #' # Embracing an external variable works
 #' some_value <- 1
 #' mutate(pl_iris, x = {{ some_value }})
-
 mutate.RPolarsDataFrame <- function(
     .data,
     ...,
     .by = NULL,
-    .keep = c("all", "used", "unused", "none")
-  ) {
-
+    .keep = c("all", "used", "unused", "none")) {
   .keep <- rlang::arg_match0(.keep, values = c("all", "used", "unused", "none"))
 
   grps <- get_grps(.data, rlang::enquo(.by), env = rlang::current_env())
@@ -140,7 +137,14 @@ mutate.RPolarsDataFrame <- function(
 
     if (length(sub) > 0) {
       if (is_grouped) {
-        sub <- lapply(sub, \(x) x$over(grps))
+        sub <- lapply(sub, \(x) {
+          order_by <- attributes(x)[["order_by"]]
+          if (!is.null(order_by)) {
+            x$over(grps, order_by = order_by)
+          } else {
+            x$over(grps)
+          }
+        })
       }
       .data <- .data$with_columns(sub)
     }

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -61,7 +61,6 @@ summarize.RPolarsDataFrame <- function(.data, ..., .by = NULL, .groups = "drop_l
 
     if (length(sub) > 0) {
       if (is_grouped) {
-        print(sub)
         .data <- .data$group_by(grps, maintain_order = mo)$agg(sub)
       } else {
         .data <- .data$select(sub)

--- a/R/summarize.R
+++ b/R/summarize.R
@@ -61,6 +61,7 @@ summarize.RPolarsDataFrame <- function(.data, ..., .by = NULL, .groups = "drop_l
 
     if (length(sub) > 0) {
       if (is_grouped) {
+        print(sub)
         .data <- .data$group_by(grps, maintain_order = mo)$agg(sub)
       } else {
         .data <- .data$select(sub)

--- a/tests/testthat/test-explicit_namespace-lazy.R
+++ b/tests/testthat/test-explicit_namespace-lazy.R
@@ -15,13 +15,13 @@ test_that("using other package namespace works", {
   test <- polars::pl$LazyFrame(x = 1:3)
 
   expect_equal_lazy(
-    test |> mutate(y = lag(x)),
-    test |> mutate(y = dplyr::lag(x))
+    test |> mutate(y = first(x)),
+    test |> mutate(y = dplyr::first(x))
   )
 
   expect_equal_lazy(
-    test |> summarize(y = lag(x)),
-    test |> summarize(y = dplyr::lag(x))
+    test |> summarize(y = first(x)),
+    test |> summarize(y = dplyr::first(x))
   )
 
   expect_equal_lazy(

--- a/tests/testthat/test-explicit_namespace.R
+++ b/tests/testthat/test-explicit_namespace.R
@@ -11,13 +11,13 @@ test_that("using other package namespace works", {
   test <- polars::pl$DataFrame(x = 1:3)
 
   expect_equal(
-    test |> mutate(y = lag(x)),
-    test |> mutate(y = dplyr::lag(x))
+    test |> mutate(y = first(x)),
+    test |> mutate(y = dplyr::first(x))
   )
 
   expect_equal(
-    test |> summarize(y = lag(x)),
-    test |> summarize(y = dplyr::lag(x))
+    test |> summarize(y = first(x)),
+    test |> summarize(y = dplyr::first(x))
   )
 
   expect_equal(

--- a/tests/testthat/test-funs_math-lazy.R
+++ b/tests/testthat/test-funs_math-lazy.R
@@ -2,7 +2,7 @@
 
 Sys.setenv('TIDYPOLARS_TEST' = TRUE)
 
-test_that("multiplication works", {
+test_that("mathematical functions work", {
   test_df <- data.frame(
     x1 = c("a", "a", "b", "a", "c"),
     x2 = c(2, 1, 5, 3, 1),
@@ -21,18 +21,17 @@ test_that("multiplication works", {
     "cummin",
     "cumprod",
     "cumsum", "exp", "first",
-    "floor", "lag",
+    "floor",
     "last", "log", "log10",
     "rank",
     "sign",
-    "sin", "sinh", "sort",  "sqrt", "tan", "tanh"
+    "sin", "sinh", "sort", "sqrt", "tan", "tanh"
   )) {
-
-    if (i %in% c("acos", "asin", "atan", "atanh", "ceiling", "cos", "floor",
-                "sin", "tan")) {
-
+    if (i %in% c(
+      "acos", "asin", "atan", "atanh", "ceiling", "cos", "floor",
+      "sin", "tan"
+    )) {
       variable <- "value_trigo"
-
     } else if (i %in% c("abs", "mean")) {
       variable <- "value_mix"
     } else {
@@ -50,7 +49,6 @@ test_that("multiplication works", {
       pull(foo)
 
     expect_equal_lazy(pol, res, info = i)
-
   }
 })
 
@@ -64,10 +62,12 @@ test_that("warns if unknown args", {
     value_with_NA = c(-2, -1, NA, 1, 2)
   )
   test <- pl$LazyFrame(test_df)
-  foo <- test |> mutate(x = sample(x2)) |> pull(x)
-  
+  foo <- test |>
+    mutate(x = sample(x2)) |>
+    pull(x)
+
   expect_true(all(foo %in% c(1, 2, 3, 5)))
-  
+
   expect_warning(
     test |> mutate(x = sample(x2, prob = 0.5)),
     "doesn't know how to use some arguments"
@@ -93,7 +93,7 @@ test_that("diff() works", {
       pull(foo) |>
       suppressWarnings()
   )
-  
+
   expect_equal_lazy(
     test |>
       summarize(foo = diff(value, lag = 2)) |>
@@ -103,7 +103,7 @@ test_that("diff() works", {
       pull(foo) |>
       suppressWarnings()
   )
-  
+
   expect_error_lazy(
     test |> summarize(foo = diff(value, differences = 2)),
     "doesn't support"

--- a/tests/testthat/test-funs_math.R
+++ b/tests/testthat/test-funs_math.R
@@ -1,4 +1,4 @@
-test_that("multiplication works", {
+test_that("mathematical functions work", {
   test_df <- data.frame(
     x1 = c("a", "a", "b", "a", "c"),
     x2 = c(2, 1, 5, 3, 1),
@@ -17,18 +17,17 @@ test_that("multiplication works", {
     "cummin",
     "cumprod",
     "cumsum", "exp", "first",
-    "floor", "lag",
+    "floor",
     "last", "log", "log10",
     "rank",
     "sign",
-    "sin", "sinh", "sort",  "sqrt", "tan", "tanh"
+    "sin", "sinh", "sort", "sqrt", "tan", "tanh"
   )) {
-
-    if (i %in% c("acos", "asin", "atan", "atanh", "ceiling", "cos", "floor",
-                "sin", "tan")) {
-
+    if (i %in% c(
+      "acos", "asin", "atan", "atanh", "ceiling", "cos", "floor",
+      "sin", "tan"
+    )) {
       variable <- "value_trigo"
-
     } else if (i %in% c("abs", "mean")) {
       variable <- "value_mix"
     } else {
@@ -46,7 +45,6 @@ test_that("multiplication works", {
       pull(foo)
 
     expect_equal(pol, res, info = i)
-
   }
 })
 
@@ -60,10 +58,12 @@ test_that("warns if unknown args", {
     value_with_NA = c(-2, -1, NA, 1, 2)
   )
   test <- pl$DataFrame(test_df)
-  foo <- test |> mutate(x = sample(x2)) |> pull(x)
-  
+  foo <- test |>
+    mutate(x = sample(x2)) |>
+    pull(x)
+
   expect_true(all(foo %in% c(1, 2, 3, 5)))
-  
+
   expect_warning(
     test |> mutate(x = sample(x2, prob = 0.5)),
     "doesn't know how to use some arguments"
@@ -89,7 +89,7 @@ test_that("diff() works", {
       pull(foo) |>
       suppressWarnings()
   )
-  
+
   expect_equal(
     test |>
       summarize(foo = diff(value, lag = 2)) |>
@@ -99,7 +99,7 @@ test_that("diff() works", {
       pull(foo) |>
       suppressWarnings()
   )
-  
+
   expect_error(
     test |> summarize(foo = diff(value, differences = 2)),
     "doesn't support"

--- a/tests/testthat/test-funs_other-lazy.R
+++ b/tests/testthat/test-funs_other-lazy.R
@@ -15,10 +15,8 @@ test_that("which.min() and which.max() work", {
       mutate(
         argmin = which.min(x),
         argmax = which.max(x),
-
         argmin_na = which.min(x_na),
         argmax_na = which.max(x_na),
-
         argmin_inf = which.min(x_inf),
         argmax_inf = which.max(x_inf)
       ),
@@ -26,10 +24,8 @@ test_that("which.min() and which.max() work", {
       mutate(
         argmin = which.min(x),
         argmax = which.max(x),
-
         argmin_na = which.min(x_na),
         argmax_na = which.max(x_na),
-
         argmin_inf = which.min(x_inf),
         argmax_inf = which.max(x_inf)
       )
@@ -547,27 +543,124 @@ test_that("row_number() works", {
 
   expect_equal_lazy(
     test4 |>
-      mutate(
-        rn = row_number(),
-        .by = grp
-      ) |>
-      summarize(
-        foo = sum(val),
-        .by = rn
-      ) |>
+      mutate(rn = row_number(), .by = grp) |>
+      summarize(foo = sum(val), .by = rn) |>
       arrange(rn) |>
       as_tibble(),
     test4 |>
       as_tibble() |>
-      mutate(
-        rn = row_number(),
-        .by = grp
-      ) |>
-      summarize(
-        foo = sum(val),
-        .by = rn
-      ),
+      mutate(rn = row_number(), .by = grp) |>
+      summarize(foo = sum(val), .by = rn),
     ignore_attr = TRUE
+  )
+})
+
+test_that("stats::lag() is not supported", {
+  dat <- pl$LazyFrame(x = c(10, 20, 30, 40, 10, 20, 30, 40))
+  expect_error_lazy(
+    dat |> mutate(x_lag = stats::lag(x)),
+    "doesn't know how to translate this function: `stats::lag()`",
+    fixed = TRUE
+  )
+})
+
+test_that("dplyr::lag() works", {
+  dat <- data.frame(
+    g = c(1, 1, 1, 1, 2, 2, 2, 2),
+    t = c(1, 2, 3, 4, 4, 1, 2, 3),
+    x = c(10, 20, 30, 40, 10, 20, 30, 40)
+  )
+  expect_equal_lazy(
+    dat |>
+      as_polars_lf() |>
+      mutate(x_lag = lag(x, order_by = t), .by = g),
+    dat |>
+      mutate(x_lag = lag(x, order_by = t), .by = g)
+  )
+  expect_equal_lazy(
+    dat |>
+      as_polars_lf() |>
+      mutate(x_lag = lag(x, order_by = t, n = 2), .by = g),
+    dat |>
+      mutate(x_lag = lag(x, order_by = t, n = 2), .by = g)
+  )
+
+  # With one group only
+  dat <- data.frame(
+    g = c(1, 1, 1, 1),
+    t = c(1, 2, 3, 4),
+    x = c(10, 20, 30, 40)
+  )
+  expect_equal_lazy(
+    dat |>
+      as_polars_lf() |>
+      mutate(x_lag = lag(x, order_by = t), .by = g),
+    dat |>
+      mutate(x_lag = lag(x, order_by = t), .by = g)
+  )
+
+  # fill NA
+  dat <- data.frame(
+    g = c(1, 1, 1, 1, 2),
+    t = c(1, 2, 3, 4, 5),
+    x = c(10, 20, 30, 40, 50)
+  )
+  expect_equal_lazy(
+    dat |>
+      as_polars_lf() |>
+      mutate(x_lag = lag(x, order_by = t, default = 99), .by = g),
+    dat |>
+      mutate(x_lag = lag(x, order_by = t, default = 99), .by = g)
+  )
+})
+
+test_that("dplyr::lead() works", {
+  dat <- data.frame(
+    g = c(1, 1, 1, 1, 2, 2, 2, 2),
+    t = c(1, 2, 3, 4, 4, 1, 2, 3),
+    x = c(10, 20, 30, 40, 10, 20, 30, 40)
+  )
+  expect_equal_lazy(
+    dat |>
+      as_polars_lf() |>
+      mutate(x_lead = lead(x, order_by = t), .by = g),
+    dat |>
+      mutate(x_lead = lead(x, order_by = t), .by = g)
+  )
+  expect_equal_lazy(
+    dat |>
+      as_polars_lf() |>
+      mutate(x_lead = lead(x, order_by = t, n = 2), .by = g),
+    dat |>
+      mutate(x_lead = lead(x, order_by = t, n = 2), .by = g)
+  )
+
+  # With one group only
+  dat <- data.frame(
+    g = c(1, 1, 1, 1),
+    t = c(1, 2, 3, 4),
+    x = c(10, 20, 30, 40)
+  )
+  expect_equal_lazy(
+    dat |>
+      as_polars_lf() |>
+      mutate(x_lead = lead(x, order_by = t), .by = g),
+    dat |>
+      mutate(x_lead = lead(x, order_by = t), .by = g)
+  )
+
+  # fill NA
+  dat <- data.frame(
+    g = c(1, 1, 1, 1, 2),
+    t = c(1, 2, 3, 4, 5),
+    x = c(10, 20, 30, 40, 50)
+  )
+  expect_equal_lazy(
+    dat |>
+      as_polars_lf() |>
+      mutate(x_lead = lead(x, order_by = t, default = 99), .by = g),
+    dat |>
+      mutate(x_lead = lead(x, order_by = t, default = 99), .by = g)
   )
 })
 

--- a/tests/testthat/test-funs_other-lazy.R
+++ b/tests/testthat/test-funs_other-lazy.R
@@ -573,16 +573,16 @@ test_that("dplyr::lag() works", {
   expect_equal_lazy(
     dat |>
       as_polars_lf() |>
-      mutate(x_lag = lag(x, order_by = t), .by = g),
+      mutate(x_lag = dplyr::lag(x, order_by = t), .by = g),
     dat |>
-      mutate(x_lag = lag(x, order_by = t), .by = g)
+      mutate(x_lag = dplyr::lag(x, order_by = t), .by = g)
   )
   expect_equal_lazy(
     dat |>
       as_polars_lf() |>
-      mutate(x_lag = lag(x, order_by = t, n = 2), .by = g),
+      mutate(x_lag = dplyr::lag(x, order_by = t, n = 2), .by = g),
     dat |>
-      mutate(x_lag = lag(x, order_by = t, n = 2), .by = g)
+      mutate(x_lag = dplyr::lag(x, order_by = t, n = 2), .by = g)
   )
 
   # With one group only
@@ -594,9 +594,9 @@ test_that("dplyr::lag() works", {
   expect_equal_lazy(
     dat |>
       as_polars_lf() |>
-      mutate(x_lag = lag(x, order_by = t), .by = g),
+      mutate(x_lag = dplyr::lag(x, order_by = t), .by = g),
     dat |>
-      mutate(x_lag = lag(x, order_by = t), .by = g)
+      mutate(x_lag = dplyr::lag(x, order_by = t), .by = g)
   )
 
   # fill NA
@@ -608,9 +608,9 @@ test_that("dplyr::lag() works", {
   expect_equal_lazy(
     dat |>
       as_polars_lf() |>
-      mutate(x_lag = lag(x, order_by = t, default = 99), .by = g),
+      mutate(x_lag = dplyr::lag(x, order_by = t, default = 99), .by = g),
     dat |>
-      mutate(x_lag = lag(x, order_by = t, default = 99), .by = g)
+      mutate(x_lag = dplyr::lag(x, order_by = t, default = 99), .by = g)
   )
 })
 

--- a/tests/testthat/test-funs_other.R
+++ b/tests/testthat/test-funs_other.R
@@ -566,19 +566,21 @@ test_that("dplyr::lag() works", {
     t = c(1, 2, 3, 4, 4, 1, 2, 3),
     x = c(10, 20, 30, 40, 10, 20, 30, 40)
   )
+  # Need to explicitly namespace this because there is no pl_lag(). Without
+  # namespace it works fine in interactive mode but not via devtools::test().
   expect_equal(
     dat |>
       as_polars_df() |>
-      mutate(x_lag = lag(x, order_by = t), .by = g),
+      mutate(x_lag = dplyr::lag(x, order_by = t), .by = g),
     dat |>
-      mutate(x_lag = lag(x, order_by = t), .by = g)
+      mutate(x_lag = dplyr::lag(x, order_by = t), .by = g)
   )
   expect_equal(
     dat |>
       as_polars_df() |>
-      mutate(x_lag = lag(x, order_by = t, n = 2), .by = g),
+      mutate(x_lag = dplyr::lag(x, order_by = t, n = 2), .by = g),
     dat |>
-      mutate(x_lag = lag(x, order_by = t, n = 2), .by = g)
+      mutate(x_lag = dplyr::lag(x, order_by = t, n = 2), .by = g)
   )
 
   # With one group only
@@ -590,9 +592,9 @@ test_that("dplyr::lag() works", {
   expect_equal(
     dat |>
       as_polars_df() |>
-      mutate(x_lag = lag(x, order_by = t), .by = g),
+      mutate(x_lag = dplyr::lag(x, order_by = t), .by = g),
     dat |>
-      mutate(x_lag = lag(x, order_by = t), .by = g)
+      mutate(x_lag = dplyr::lag(x, order_by = t), .by = g)
   )
 
   # fill NA
@@ -604,9 +606,9 @@ test_that("dplyr::lag() works", {
   expect_equal(
     dat |>
       as_polars_df() |>
-      mutate(x_lag = lag(x, order_by = t, default = 99), .by = g),
+      mutate(x_lag = dplyr::lag(x, order_by = t, default = 99), .by = g),
     dat |>
-      mutate(x_lag = lag(x, order_by = t, default = 99), .by = g)
+      mutate(x_lag = dplyr::lag(x, order_by = t, default = 99), .by = g)
   )
 })
 

--- a/tests/testthat/test-funs_other.R
+++ b/tests/testthat/test-funs_other.R
@@ -11,10 +11,8 @@ test_that("which.min() and which.max() work", {
       mutate(
         argmin = which.min(x),
         argmax = which.max(x),
-
         argmin_na = which.min(x_na),
         argmax_na = which.max(x_na),
-
         argmin_inf = which.min(x_inf),
         argmax_inf = which.max(x_inf)
       ),
@@ -22,10 +20,8 @@ test_that("which.min() and which.max() work", {
       mutate(
         argmin = which.min(x),
         argmax = which.max(x),
-
         argmin_na = which.min(x_na),
         argmax_na = which.max(x_na),
-
         argmin_inf = which.min(x_inf),
         argmax_inf = which.max(x_inf)
       )
@@ -543,26 +539,91 @@ test_that("row_number() works", {
 
   expect_equal(
     test4 |>
-      mutate(
-        rn = row_number(),
-        .by = grp
-      ) |>
-      summarize(
-        foo = sum(val),
-        .by = rn
-      ) |>
+      mutate(rn = row_number(), .by = grp) |>
+      summarize(foo = sum(val), .by = rn) |>
       arrange(rn) |>
       as_tibble(),
     test4 |>
       as_tibble() |>
-      mutate(
-        rn = row_number(),
-        .by = grp
-      ) |>
-      summarize(
-        foo = sum(val),
-        .by = rn
-      ),
+      mutate(rn = row_number(), .by = grp) |>
+      summarize(foo = sum(val), .by = rn),
     ignore_attr = TRUE
+  )
+})
+
+test_that("stats::lag() is not supported", {
+  dat <- pl$DataFrame(x = c(10, 20, 30, 40, 10, 20, 30, 40))
+  expect_error(
+    dat |> mutate(x_lag = stats::lag(x)),
+    "doesn't know how to translate this function: `stats::lag()`",
+    fixed = TRUE
+  )
+})
+
+test_that("dplyr::lag() works", {
+  dat <- pl$DataFrame(
+    g = c(1, 1, 1, 1, 2, 2, 2, 2),
+    t = c(1, 2, 3, 4, 4, 1, 2, 3),
+    x = c(10, 20, 30, 40, 10, 20, 30, 40)
+  )
+  expect_equal(
+    dat |>
+      mutate(
+        x_lag = lag(x, order_by = t),
+        .by = g
+      ),
+    dat |>
+      as.data.frame() |>
+      mutate(
+        x_lag = lag(x, order_by = t),
+        .by = g
+      )
+  )
+  expect_equal(
+    dat |>
+      mutate(
+        x_lag = lag(x, order_by = t, n = 2),
+        .by = g
+      ),
+    dat |>
+      as.data.frame() |>
+      mutate(
+        x_lag = lag(x, order_by = t, n = 2),
+        .by = g
+      )
+  )
+})
+
+test_that("dplyr::lead() works", {
+  dat <- pl$DataFrame(
+    g = c(1, 1, 1, 1, 2, 2, 2, 2),
+    t = c(1, 2, 3, 4, 4, 1, 2, 3),
+    x = c(10, 20, 30, 40, 10, 20, 30, 40)
+  )
+  expect_equal(
+    dat |>
+      mutate(
+        x_lead = lead(x, order_by = t),
+        .by = g
+      ),
+    dat |>
+      as.data.frame() |>
+      mutate(
+        x_lead = lead(x, order_by = t),
+        .by = g
+      )
+  )
+  expect_equal(
+    dat |>
+      mutate(
+        x_lead = lead(x, order_by = t, n = 2),
+        .by = g
+      ),
+    dat |>
+      as.data.frame() |>
+      mutate(
+        x_lead = lead(x, order_by = t, n = 2),
+        .by = g
+      )
   )
 })

--- a/tests/testthat/test-funs_other.R
+++ b/tests/testthat/test-funs_other.R
@@ -561,69 +561,101 @@ test_that("stats::lag() is not supported", {
 })
 
 test_that("dplyr::lag() works", {
-  dat <- pl$DataFrame(
+  dat <- data.frame(
     g = c(1, 1, 1, 1, 2, 2, 2, 2),
     t = c(1, 2, 3, 4, 4, 1, 2, 3),
     x = c(10, 20, 30, 40, 10, 20, 30, 40)
   )
   expect_equal(
     dat |>
-      mutate(
-        x_lag = lag(x, order_by = t),
-        .by = g
-      ),
+      as_polars_df() |>
+      mutate(x_lag = lag(x, order_by = t), .by = g),
     dat |>
-      as.data.frame() |>
-      mutate(
-        x_lag = lag(x, order_by = t),
-        .by = g
-      )
+      mutate(x_lag = lag(x, order_by = t), .by = g)
   )
   expect_equal(
     dat |>
-      mutate(
-        x_lag = lag(x, order_by = t, n = 2),
-        .by = g
-      ),
+      as_polars_df() |>
+      mutate(x_lag = lag(x, order_by = t, n = 2), .by = g),
     dat |>
-      as.data.frame() |>
-      mutate(
-        x_lag = lag(x, order_by = t, n = 2),
-        .by = g
-      )
+      mutate(x_lag = lag(x, order_by = t, n = 2), .by = g)
+  )
+
+  # With one group only
+  dat <- data.frame(
+    g = c(1, 1, 1, 1),
+    t = c(1, 2, 3, 4),
+    x = c(10, 20, 30, 40)
+  )
+  expect_equal(
+    dat |>
+      as_polars_df() |>
+      mutate(x_lag = lag(x, order_by = t), .by = g),
+    dat |>
+      mutate(x_lag = lag(x, order_by = t), .by = g)
+  )
+
+  # fill NA
+  dat <- data.frame(
+    g = c(1, 1, 1, 1, 2),
+    t = c(1, 2, 3, 4, 5),
+    x = c(10, 20, 30, 40, 50)
+  )
+  expect_equal(
+    dat |>
+      as_polars_df() |>
+      mutate(x_lag = lag(x, order_by = t, default = 99), .by = g),
+    dat |>
+      mutate(x_lag = lag(x, order_by = t, default = 99), .by = g)
   )
 })
 
 test_that("dplyr::lead() works", {
-  dat <- pl$DataFrame(
+  dat <- data.frame(
     g = c(1, 1, 1, 1, 2, 2, 2, 2),
     t = c(1, 2, 3, 4, 4, 1, 2, 3),
     x = c(10, 20, 30, 40, 10, 20, 30, 40)
   )
   expect_equal(
     dat |>
-      mutate(
-        x_lead = lead(x, order_by = t),
-        .by = g
-      ),
+      as_polars_df() |>
+      mutate(x_lead = lead(x, order_by = t), .by = g),
     dat |>
-      as.data.frame() |>
-      mutate(
-        x_lead = lead(x, order_by = t),
-        .by = g
-      )
+      mutate(x_lead = lead(x, order_by = t), .by = g)
   )
   expect_equal(
     dat |>
-      mutate(
-        x_lead = lead(x, order_by = t, n = 2),
-        .by = g
-      ),
+      as_polars_df() |>
+      mutate(x_lead = lead(x, order_by = t, n = 2), .by = g),
     dat |>
-      as.data.frame() |>
-      mutate(
-        x_lead = lead(x, order_by = t, n = 2),
-        .by = g
-      )
+      mutate(x_lead = lead(x, order_by = t, n = 2), .by = g)
+  )
+
+  # With one group only
+  dat <- data.frame(
+    g = c(1, 1, 1, 1),
+    t = c(1, 2, 3, 4),
+    x = c(10, 20, 30, 40)
+  )
+  expect_equal(
+    dat |>
+      as_polars_df() |>
+      mutate(x_lead = lead(x, order_by = t), .by = g),
+    dat |>
+      mutate(x_lead = lead(x, order_by = t), .by = g)
+  )
+
+  # fill NA
+  dat <- data.frame(
+    g = c(1, 1, 1, 1, 2),
+    t = c(1, 2, 3, 4, 5),
+    x = c(10, 20, 30, 40, 50)
+  )
+  expect_equal(
+    dat |>
+      as_polars_df() |>
+      mutate(x_lead = lead(x, order_by = t, default = 99), .by = g),
+    dat |>
+      mutate(x_lead = lead(x, order_by = t, default = 99), .by = g)
   )
 })

--- a/tests/testthat/test-pull-lazy.R
+++ b/tests/testthat/test-pull-lazy.R
@@ -2,7 +2,7 @@
 
 Sys.setenv('TIDYPOLARS_TEST' = TRUE)
 
-test_that("multiplication works", {
+test_that("basic behavior works", {
   test <- polars::pl$LazyFrame(mtcars)
 
   expect_equal_lazy(

--- a/tests/testthat/test-pull.R
+++ b/tests/testthat/test-pull.R
@@ -1,4 +1,4 @@
-test_that("multiplication works", {
+test_that("basic behavior works", {
   test <- polars::pl$DataFrame(mtcars)
 
   expect_equal(

--- a/vignettes/r-and-polars-expressions.Rmd
+++ b/vignettes/r-and-polars-expressions.Rmd
@@ -28,8 +28,8 @@ library(dplyr, warn.conflicts = FALSE)
 
 filter(mtcars, am + gear > carb)
 mutate(mtcars, x = (qsec - mean(qsec)) / sd(qsec))
-mtcars |> 
-  group_by(cyl) |> 
+mtcars |>
+  group_by(cyl) |>
   summarize(x = mean(qsec) / sd(qsec))
 ```
 
@@ -104,8 +104,8 @@ this argument and warns the user:
 library(tidypolars)
 library(polars)
 
-mtcars |> 
-  as_polars_df() |> 
+mtcars |>
+  as_polars_df() |>
   mutate(x = mean(mpg, trim = 2))
 ```
 
@@ -139,8 +139,8 @@ This function correctly returns a Polars expression, so we can now use it like
 any other function:
 
 ```{r}
-mtcars |> 
-  as_polars_df() |> 
+mtcars |>
+  as_polars_df() |>
   mutate(x = pl_standardize(mpg))
 ```
 
@@ -152,8 +152,8 @@ function that applies a function (or a list of functions) to a selection of
 columns. It accepts built-in functions, UDFs, and anonymous functions.
 
 ```{r}
-mtcars |> 
-  as_polars_df() |> 
+mtcars |>
+  as_polars_df() |>
   mutate(
     across(
       .cols = contains("a"),
@@ -166,15 +166,15 @@ Similarly, UDFs and anonymous functions will error if they don't return a Polars
 expression:
 
 ```{r error=TRUE}
-mtcars |> 
-  as_polars_df() |> 
+mtcars |>
+  as_polars_df() |>
   mutate(
     across(
       .cols = contains("a"),
       .fns = list(
-        mean = mean,  
+        mean = mean,
         function(x) {
-           (x - mean(x)) / sd(x)
+          (x - mean(x)) / sd(x)
         },
         ~ sd(.x)
       )
@@ -191,107 +191,108 @@ library(dplyr)
 library(knitr)
 out <- tribble(
   ~Package, ~Function,
-  "`base`",             "`abs`",
-  "`base`",             "`acos`", 
-  "`base`",             "`acosh`", 
-  "`base`",             "`all`",
-  "`base`",             "`any`",
-  "`base`",             "`asin`",
-  "`base`",             "`asinh`", 
-  "`base`",             "`atan`", 
-  "`base`",             "`atanh`",
-  "`base`",             "`ceiling`",
-  "`base`",             "`cos`", 
-  "`base`",             "`cosh`",
-  "`base`",             "`cummin`",
-  "`base`",             "`cumsum`", 
-  "`base`",             "`diff`", 
-  "`base`",             "`exp`", 
-  "`base`",             "`floor`",
-  "`base`",             "`grepl`",
-  "`base`",             "`ifelse`",
-  "`base`",             "`ISOdatetime`",
-  "`base`",             "`length`",
-  "`base`",             "`log`", 
-  "`base`",             "`log10`",
-  "`base`",             "`max`", 
-  "`base`",             "`mean`", 
-  "`base`",             "`min`",
-  "`base`",             "`nchar`",
-  "`base`",             "`paste0`",
-  "`base`",             "`paste`",
-  "`base`",             "`rank`",
-  "`base`",             "`rev`",
-  "`base`",             "`round`",
-  "`base`",             "`sin`", 
-  "`base`",             "`sinh`", 
-  "`base`",             "`sort`", 
-  "`base`",             "`sqrt`", 
-  "`base`",             "`strptime`",
-  "`base`",             "`substr`",
-  "`base`",             "`tan`", 
-  "`base`",             "`tanh`",
-  "`base`",             "`tolower`",
-  "`base`",             "`toupper`",
-  "`base`",             "`unique`",
-  "`base`",             "`which.min`",
-  "`base`",             "`which.max`",
-  "`dplyr`",            "`between`",
-  "`dplyr`",            "`case_match`",
-  "`dplyr`",            "`case_when`",
-  "`dplyr`",            "`coalesce`",
-  "`dplyr`",            "`consecutive_id`",
-  "`dplyr`",            "`dense_rank`",
-  "`dplyr`",            "`first`",
-  "`dplyr`",            "`group_keys`",
-  "`dplyr`",            "`group_vars`",
-  "`dplyr`",            "`if_else`",
-  "`dplyr`",            "`lag`",
-  "`dplyr`",            "`last`",
-  "`dplyr`",            "`min_rank`",
-  "`dplyr`",            "`n`",
-  "`dplyr`",            "`nth`",
-  "`dplyr`",            "`n_distinct`",
-  "`dplyr`",            "`row_number`",
-  "`lubridate`",        "`ddays`",
-  "`lubridate`",        "`dhours`",
-  "`lubridate`",        "`dmilliseconds`",
-  "`lubridate`",        "`dminutes`",
-  "`lubridate`",        "`dseconds`",
-  "`lubridate`",        "`dweeks`",
-  "`lubridate`",        "`make_date`",
-  "`lubridate`",        "`make_datetime`",
-  "`lubridate`",        "`wday`",
-  "`stats`",            "`median`", 
-  "`stats`",            "`lag`", 
-  "`stats`",            "`sd`", 
-  "`stats`",            "`var`",
-  "`stringr`",          "`regex`",
-  "`stringr`",          "`str_count`",
-  "`stringr`",          "`str_detect`",
-  "`stringr`",          "`str_dup`",
-  "`stringr`",          "`str_ends`",
-  "`stringr`",          "`str_extract`",
-  "`stringr`",          "`str_extract_all`",
-  "`stringr`",          "`str_length`",
-  "`stringr`",          "`str_pad`",
-  "`stringr`",          "`str_remove`",
-  "`stringr`",          "`str_remove_all`",
-  "`stringr`",          "`str_replace`",
-  "`stringr`",          "`str_replace_all`",
-  "`stringr`",          "`str_split`",
-  "`stringr`",          "`str_split_i`",
-  "`stringr`",          "`str_squish`",
-  "`stringr`",          "`str_starts`",
-  "`stringr`",          "`str_sub`",
-  "`stringr`",          "`str_trim`",
-  "`stringr`",          "`str_to_lower`",
-  "`stringr`",          "`str_to_title`",
-  "`stringr`",          "`str_to_upper`",
-  "`stringr`",          "`str_trunc`",
-  "`stringr`",          "`word`",
-  "`tidyr`",            "`replace_na`",
-  "`tools`",            "`toTitleCase`"
+  "`base`", "`abs`",
+  "`base`", "`acos`",
+  "`base`", "`acosh`",
+  "`base`", "`all`",
+  "`base`", "`any`",
+  "`base`", "`asin`",
+  "`base`", "`asinh`",
+  "`base`", "`atan`",
+  "`base`", "`atanh`",
+  "`base`", "`ceiling`",
+  "`base`", "`cos`",
+  "`base`", "`cosh`",
+  "`base`", "`cummin`",
+  "`base`", "`cumsum`",
+  "`base`", "`diff`",
+  "`base`", "`exp`",
+  "`base`", "`floor`",
+  "`base`", "`grepl`",
+  "`base`", "`ifelse`",
+  "`base`", "`ISOdatetime`",
+  "`base`", "`length`",
+  "`base`", "`log`",
+  "`base`", "`log10`",
+  "`base`", "`max`",
+  "`base`", "`mean`",
+  "`base`", "`min`",
+  "`base`", "`nchar`",
+  "`base`", "`paste0`",
+  "`base`", "`paste`",
+  "`base`", "`rank`",
+  "`base`", "`rev`",
+  "`base`", "`round`",
+  "`base`", "`sin`",
+  "`base`", "`sinh`",
+  "`base`", "`sort`",
+  "`base`", "`sqrt`",
+  "`base`", "`strptime`",
+  "`base`", "`substr`",
+  "`base`", "`tan`",
+  "`base`", "`tanh`",
+  "`base`", "`tolower`",
+  "`base`", "`toupper`",
+  "`base`", "`unique`",
+  "`base`", "`which.min`",
+  "`base`", "`which.max`",
+  "`dplyr`", "`between`",
+  "`dplyr`", "`case_match`",
+  "`dplyr`", "`case_when`",
+  "`dplyr`", "`coalesce`",
+  "`dplyr`", "`consecutive_id`",
+  "`dplyr`", "`dense_rank`",
+  "`dplyr`", "`first`",
+  "`dplyr`", "`group_keys`",
+  "`dplyr`", "`group_vars`",
+  "`dplyr`", "`if_else`",
+  "`dplyr`", "`lag`",
+  "`dplyr`", "`lead`",
+  "`dplyr`", "`last`",
+  "`dplyr`", "`min_rank`",
+  "`dplyr`", "`n`",
+  "`dplyr`", "`nth`",
+  "`dplyr`", "`n_distinct`",
+  "`dplyr`", "`row_number`",
+  "`lubridate`", "`ddays`",
+  "`lubridate`", "`dhours`",
+  "`lubridate`", "`dmilliseconds`",
+  "`lubridate`", "`dminutes`",
+  "`lubridate`", "`dseconds`",
+  "`lubridate`", "`dweeks`",
+  "`lubridate`", "`make_date`",
+  "`lubridate`", "`make_datetime`",
+  "`lubridate`", "`wday`",
+  "`stats`", "`median`",
+  "`stats`", "`lag`",
+  "`stats`", "`sd`",
+  "`stats`", "`var`",
+  "`stringr`", "`regex`",
+  "`stringr`", "`str_count`",
+  "`stringr`", "`str_detect`",
+  "`stringr`", "`str_dup`",
+  "`stringr`", "`str_ends`",
+  "`stringr`", "`str_extract`",
+  "`stringr`", "`str_extract_all`",
+  "`stringr`", "`str_length`",
+  "`stringr`", "`str_pad`",
+  "`stringr`", "`str_remove`",
+  "`stringr`", "`str_remove_all`",
+  "`stringr`", "`str_replace`",
+  "`stringr`", "`str_replace_all`",
+  "`stringr`", "`str_split`",
+  "`stringr`", "`str_split_i`",
+  "`stringr`", "`str_squish`",
+  "`stringr`", "`str_starts`",
+  "`stringr`", "`str_sub`",
+  "`stringr`", "`str_trim`",
+  "`stringr`", "`str_to_lower`",
+  "`stringr`", "`str_to_title`",
+  "`stringr`", "`str_to_upper`",
+  "`stringr`", "`str_trunc`",
+  "`stringr`", "`word`",
+  "`tidyr`", "`replace_na`",
+  "`tools`", "`toTitleCase`"
 ) |>
   mutate(Notes = case_when(
     Package == "`lubridate`" & Function == "`make_datetime`" ~ "In `lubridate::make_datetime()`, when there is an overflow (for example `hours = 25`), then it is automatically converted to the higher unit (for example 1 day and 1h). In Polars, this returns `NA`.",
@@ -300,8 +301,8 @@ out <- tribble(
     Package == "`stringr`" & Function == "`str_to_title`" ~ "Letters following apostrophe will be capitalized as well, which differs from the `stringr` implementation.",
     Package == "`tools`" & Function == "`toTitleCase`" ~ "Letters following apostrophe will be capitalized as well, which differs from the `tools` implementation.",
     .default = ""
-  )) |> 
+  )) |>
   arrange(Package)
 
-kable(out) 
+kable(out)
 ```


### PR DESCRIPTION
Close #124.

Sth that doesn't work for now (single group):
```r
df = pl$DataFrame(
  g = 1,
  t = c(4, 1, 2, 3),
  x = c(10, 20, 30, 40)
)

df |> 
  as_tibble() |> 
  mutate(
    x_lag = lag(x, order_by = t),
    .by = g
  )
# A tibble: 4 × 4
      g     t     x x_lag
  <dbl> <dbl> <dbl> <dbl>
1     1     4    10    40
2     1     1    20    NA
3     1     2    30    20
4     1     3    40    30

  df |> 
    mutate(
      x_lag = lag(x, order_by = t),
      .by = g
    )
shape: (4, 4)
┌─────┬─────┬──────┬───────┐
│ g   ┆ t   ┆ x    ┆ x_lag │
│ --- ┆ --- ┆ ---  ┆ ---   │
│ f64 ┆ f64 ┆ f64  ┆ f64   │
╞═════╪═════╪══════╪═══════╡
│ 1.0 ┆ 4.0 ┆ 10.0 ┆ null  │
│ 1.0 ┆ 1.0 ┆ 20.0 ┆ 20.0  │
│ 1.0 ┆ 2.0 ┆ 30.0 ┆ 30.0  │
│ 1.0 ┆ 3.0 ┆ 40.0 ┆ 40.0  │
└─────┴─────┴──────┴───────┘
```