### PR TITLE
Add option to keep track of filenames in `scan_csv_polars()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
   - an argument that doesn't exist at all, they error.
 
 * Add support for argument `explicit` in `tidyr::complete()`.
-* Add option to keep track of filenames in `scan_csv_polars()`
+* Add option to keep track of filenames in `scan_csv_polars()` (#171 @ginolhac)
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
   - an argument that doesn't exist at all, they error.
 
 * Add support for argument `explicit` in `tidyr::complete()`.
+* Add option to keep track of filenames in `scan_csv_polars()`
 
 ## Bug fixes
 

--- a/R/read_scan.R
+++ b/R/read_scan.R
@@ -136,7 +136,8 @@ read_csv_polars <- function(
   eol_char = "\n",
   raise_if_empty = TRUE,
   truncate_ragged_lines = FALSE,
-  reuse_downloaded = TRUE
+  reuse_downloaded = TRUE,
+  include_file_paths = NULL
 ) {
   rlang::arg_match0(encoding, values = c("utf8", "utf8-lossy"))
   rlang::check_dots_empty()
@@ -164,7 +165,8 @@ read_csv_polars <- function(
     eol_char = eol_char,
     raise_if_empty = raise_if_empty,
     truncate_ragged_lines = truncate_ragged_lines,
-    reuse_downloaded = reuse_downloaded
+    reuse_downloaded = reuse_downloaded,
+    include_file_paths = include_file_paths
   ) |>
     compute()
 }
@@ -196,7 +198,8 @@ scan_csv_polars <- function(
   eol_char = "\n",
   raise_if_empty = TRUE,
   truncate_ragged_lines = FALSE,
-  reuse_downloaded = TRUE
+  reuse_downloaded = TRUE,
+  include_file_paths = NULL
 ) {
   rlang::arg_match0(encoding, values = c("utf8", "utf8-lossy"))
   rlang::check_dots_empty()
@@ -224,7 +227,8 @@ scan_csv_polars <- function(
     eol_char = eol_char,
     raise_if_empty = raise_if_empty,
     truncate_ragged_lines = truncate_ragged_lines,
-    reuse_downloaded = reuse_downloaded
+    reuse_downloaded = reuse_downloaded,
+    include_file_paths = include_file_paths
   )
 }
 

--- a/man/from_csv.Rd
+++ b/man/from_csv.Rd
@@ -30,7 +30,8 @@ read_csv_polars(
   eol_char = "\\n",
   raise_if_empty = TRUE,
   truncate_ragged_lines = FALSE,
-  reuse_downloaded = TRUE
+  reuse_downloaded = TRUE,
+  include_file_paths = NULL
 )
 
 scan_csv_polars(
@@ -57,7 +58,8 @@ scan_csv_polars(
   eol_char = "\\n",
   raise_if_empty = TRUE,
   truncate_ragged_lines = FALSE,
-  reuse_downloaded = TRUE
+  reuse_downloaded = TRUE,
+  include_file_paths = NULL
 )
 }
 \arguments{
@@ -145,6 +147,9 @@ DataFrame or LazyFrame.}
 
 \item{reuse_downloaded}{If \code{TRUE}(default) and a URL was provided, cache the
 downloaded files in session for an easy reuse.}
+
+\item{include_file_paths}{Include the path of the source file(s) as a column
+with this name.}
 }
 \description{
 \code{read_csv_polars()} imports the data as a Polars DataFrame.


### PR DESCRIPTION
Hello Etienne,

using `scan_csv_polars()` the argument `include_file_paths` was missing while present in other `scan_xxx_polars()`.
Looking at [the **polars** docs](https://docs.pola.rs/api/python/dev/reference/api/polars.scan_csv.html#polars.scan_csv ) the option is available so I added it. 
"Works for me" on my local attempt.

Best wishes