### PR TITLE
implementation of the `date()` function

### DIFF
--- a/R/funs-date.R
+++ b/R/funs-date.R
@@ -78,11 +78,10 @@ pl_second_lubridate <- function(x, ...) {
 }
 
 # Date-time helpers --------------------------------------
-
 # TODO: implement when $dt$date() is in r-polars
-# pl_date_lubridate <- function(x) {
-#   x$dt$date()
-# }
+pl_date_lubridate <- function(x) {
+  pl$date(year = x$dt$year(), month = x$dt$month(), day = x$dt$day())
+}
 
 # Durations --------------------------------------
 

--- a/R/funs-date.R
+++ b/R/funs-date.R
@@ -79,8 +79,12 @@ pl_second_lubridate <- function(x, ...) {
 
 # Date-time helpers --------------------------------------
 # TODO: implement when $dt$date() is in r-polars
-pl_date_lubridate <- function(x) {
-  pl$date(year = x$dt$year(), month = x$dt$month(), day = x$dt$day())
+pl_date_lubridate <- function(x, ...) {
+  check_empty_dots(...)
+  year <- x$dt$year()
+  month <- x$dt$month()
+  day <- x$dt$day()
+  pl$date(year = year, month = month, day = day)
 }
 
 # Durations --------------------------------------

--- a/tests/testthat/test-funs-date-lazy.R
+++ b/tests/testthat/test-funs-date-lazy.R
@@ -42,4 +42,25 @@ patrick::with_parameters_test_that(
   fun = c("year", "month", "day", "quarter", "mday", "yday")
 )
 
+# patrick::with_parameters_test_that(
+#   "extracting date component",
+#   {
+#     test_df <- data.frame(x1 = ymd_hms(datetime, tz = "UTC"))
+#     test <- pl$LazyFrame(x1 = ymd_hms(datetime, tz = "UTC"))
+
+#     expect_equal_or_both_error(
+#       mutate(
+#         test,
+#         x2 = date(x1)
+#       ) |>
+#         as_tibble(),
+#       mutate(
+#         test_df,
+#         x2 = date(x1)
+#       )
+#     )
+#   },
+#   datetime = c("2021-03-04 10:01:00", "1990-12-01 00:01:00")
+# )
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-funs-date-lazy.R
+++ b/tests/testthat/test-funs-date-lazy.R
@@ -42,25 +42,25 @@ patrick::with_parameters_test_that(
   fun = c("year", "month", "day", "quarter", "mday", "yday")
 )
 
-# patrick::with_parameters_test_that(
-#   "extracting date component",
-#   {
-#     test_df <- data.frame(x1 = ymd_hms(datetime, tz = "UTC"))
-#     test <- pl$LazyFrame(x1 = ymd_hms(datetime, tz = "UTC"))
+patrick::with_parameters_test_that(
+  "extracting date component",
+  {
+    test_df <- data.frame(x1 = ymd_hms(datetime, tz = "UTC"))
+    test <- pl$LazyFrame(x1 = ymd_hms(datetime, tz = "UTC"))
 
-#     expect_equal_or_both_error(
-#       mutate(
-#         test,
-#         x2 = date(x1)
-#       ) |>
-#         as_tibble(),
-#       mutate(
-#         test_df,
-#         x2 = date(x1)
-#       )
-#     )
-#   },
-#   datetime = c("2021-03-04 10:01:00", "1990-12-01 00:01:00")
-# )
+    expect_equal_or_both_error(
+      mutate(
+        test,
+        x2 = date(x1)
+      ) |>
+        as_tibble(),
+      mutate(
+        test_df,
+        x2 = date(x1)
+      )
+    )
+  },
+  datetime = c("2021-03-04 10:01:00", "1990-12-01 00:01:00")
+)
 
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-funs-date.R
+++ b/tests/testthat/test-funs-date.R
@@ -35,5 +35,5 @@ patrick::with_parameters_test_that(
       }
     )
   },
-  fun = c("year", "month", "day", "quarter", "mday", "yday")
+  fun = c("year", "month", "day", "quarter", "mday", "yday", "date")
 )

--- a/tests/testthat/test-funs-date.R
+++ b/tests/testthat/test-funs-date.R
@@ -35,5 +35,26 @@ patrick::with_parameters_test_that(
       }
     )
   },
-  fun = c("year", "month", "day", "quarter", "mday", "yday", "date")
+  fun = c("year", "month", "day", "quarter", "mday", "yday")
+)
+
+patrick::with_parameters_test_that(
+  "extracting date component",
+  {
+    test_df <- data.frame(x1 = ymd_hms(datetime, tz = "UTC"))
+    test <- pl$DataFrame(x1 = ymd_hms(datetime, tz = "UTC"))
+
+    expect_equal_or_both_error(
+      mutate(
+        test,
+        x2 = date(x1)
+      ) |>
+        as_tibble(),
+      mutate(
+        test_df,
+        x2 = date(x1)
+      )
+    )
+  },
+  datetime = c("2021-03-04 10:01:00", "1990-12-01 00:01:00")
 )

--- a/tests/testthat/test-funs_date-lazy.R
+++ b/tests/testthat/test-funs_date-lazy.R
@@ -641,4 +641,18 @@ test_that("leap_year() works", {
   )
 })
 
+
+test_that("date() works", {
+  datetime <- c("2021-03-04 10:01:00", "1990-12-01 00:01:00")
+  test_df <- data.frame(x1 = ymd_hms(datetime, tz = "UTC"))
+  test <- pl$LazyFrame(x1 = ymd_hms(datetime, tz = "UTC"))
+
+  expect_equal_lazy(
+    test |>
+      mutate(foo = date(x1)),
+    test_df |>
+      mutate(foo = date(x1))
+  )
+})
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-funs_date.R
+++ b/tests/testthat/test-funs_date.R
@@ -47,7 +47,7 @@ test_that("extracting components of date works", {
     expect_equal(pol, res, info = i)
   }
 
-  for (i in c("hour", "minute", "second")) {
+  for (i in c("hour", "minute", "second", "date")) {
     pol <- paste0("mutate(test, foo = ", i, "(YMD_HMS))") |>
       str2lang() |>
       eval() |>

--- a/tests/testthat/test-funs_date.R
+++ b/tests/testthat/test-funs_date.R
@@ -47,7 +47,7 @@ test_that("extracting components of date works", {
     expect_equal(pol, res, info = i)
   }
 
-  for (i in c("hour", "minute", "second", "date")) {
+  for (i in c("hour", "minute", "second")) {
     pol <- paste0("mutate(test, foo = ", i, "(YMD_HMS))") |>
       str2lang() |>
       eval() |>
@@ -634,5 +634,19 @@ test_that("leap_year() works", {
   expect_equal(
     mutate(test, datetime = leap_year(datetime)),
     mutate(test_df, datetime = leap_year(datetime))
+  )
+})
+
+
+test_that("date() works", {
+  datetime <- c("2021-03-04 10:01:00", "1990-12-01 00:01:00")
+  test_df <- data.frame(x1 = ymd_hms(datetime, tz = "UTC"))
+  test <- pl$DataFrame(x1 = ymd_hms(datetime, tz = "UTC"))
+
+  expect_equal(
+    test |>
+      mutate(foo = date(x1)),
+    test_df |>
+      mutate(foo = date(x1))
   )
 })


### PR DESCRIPTION
Well, it turns out that I am still not fully understanding how the link between `polars` and `tidypolars` works. Here, I tried to implement the `lubridate::date()` function. It worked well whilst I was manually running tests, but testing in the `R CMD CHECK` environment fails. What am I missing?