### PR TITLE
fix: `count()` now works on grouping variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@
 * Fix behavior of `mutate()` and `summarize()` when they don't contain any
   expression (#191).
   
-* Fix error in `count()` when it includes grouping variables (#192).
+* Fix error in `count()` when it includes grouping variables (#193).
 
 # tidypolars 0.13.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
 
 * Fix behavior of `mutate()` and `summarize()` when they don't contain any
   expression (#191).
+  
+* Fix error in `count()` when it includes grouping variables (#192).
 
 # tidypolars 0.13.0
 

--- a/R/count.R
+++ b/R/count.R
@@ -87,7 +87,7 @@ count_ <- function(x, vars, sort, name, new_col = FALSE, missing_name = FALSE) {
         pl$len()$alias(name)
       )
     } else {
-      # https://github.com/etiennebacher/tidypolars/issues/192
+      # https://github.com/etiennebacher/tidypolars/issues/193
       vars <- unique(vars)
       out <- x$group_by(vars, maintain_order = FALSE)$agg(
         pl$len()$alias(name)

--- a/R/count.R
+++ b/R/count.R
@@ -87,6 +87,8 @@ count_ <- function(x, vars, sort, name, new_col = FALSE, missing_name = FALSE) {
         pl$len()$alias(name)
       )
     } else {
+      # https://github.com/etiennebacher/tidypolars/issues/192
+      vars <- unique(vars)
       out <- x$group_by(vars, maintain_order = FALSE)$agg(
         pl$len()$alias(name)
       )

--- a/tests/testthat/test-count-lazy.R
+++ b/tests/testthat/test-count-lazy.R
@@ -133,4 +133,35 @@ test_that("message if overwriting variable", {
   )
 })
 
+test_that("count() on grouping variables", {
+  test <- pl$LazyFrame(
+    year = c(1, 1, 2, 2),
+    vals = 1:4
+  ) |>
+    group_by(year) |>
+    count(year)
+
+  expect_equal_lazy(
+    test,
+    data.frame(year = c(1, 2), n = c(2L, 2L))
+  )
+  expect_equal_lazy(group_vars(test), "year")
+  expect_false(attr(test, "maintain_grp_order"))
+
+  test <- pl$LazyFrame(
+    year = c(1, 1, 2, 2),
+    state = c("a", "a", "a", "b"),
+    vals = 1:4
+  ) |>
+    group_by(year, state) |>
+    count(year)
+
+  expect_equal_lazy(
+    test,
+    data.frame(year = c(1, 2, 2), state = c("a", "a", "b"), n = c(2L, 1L, 1L))
+  )
+  expect_equal_lazy(group_vars(test), c("year", "state"))
+  expect_false(attr(test, "maintain_grp_order"))
+})
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -128,3 +128,34 @@ test_that("message if overwriting variable", {
       pull(n)
   )
 })
+
+test_that("count() on grouping variables", {
+  test <- pl$DataFrame(
+    year = c(1, 1, 2, 2),
+    vals = 1:4
+  ) |>
+    group_by(year) |>
+    count(year)
+
+  expect_equal(
+    test,
+    data.frame(year = c(1, 2), n = c(2L, 2L))
+  )
+  expect_equal(group_vars(test), "year")
+  expect_false(attr(test, "maintain_grp_order"))
+
+  test <- pl$DataFrame(
+    year = c(1, 1, 2, 2),
+    state = c("a", "a", "a", "b"),
+    vals = 1:4
+  ) |>
+    group_by(year, state) |>
+    count(year)
+
+  expect_equal(
+    test,
+    data.frame(year = c(1, 2, 2), state = c("a", "a", "b"), n = c(2L, 1L, 1L))
+  )
+  expect_equal(group_vars(test), c("year", "state"))
+  expect_false(attr(test, "maintain_grp_order"))
+})


### PR DESCRIPTION
Fixes #192