### PR TITLE
feat: Allow `.` in `across()` formulas

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,16 +54,16 @@
 * `count()` and `add_count()` now warn or error when argument `wt` is used
   since it is not supported. The behavior depends on the global option
   `tidypolars_unknown_args` (#204).
-  
+
 * `tidypolars` has experimental support for fallback to R when a function is not
   internally translated to polars syntax. The default behavior is still to
   error, but the user can now set `options(tidypolars_fallback_to_r = TRUE)`
   to handle those unknown functions. See `?tidypolars_options` for
   details on the drawbacks of this approach (#205).
-  
-* Large performance improvement when using selection helpers (such as 
+
+* Large performance improvement when using selection helpers (such as
   `contains()`) on data with many columns (#211).
-  
+
 * `tidypolars` now exports rules to be used with `flir` for detecting deprecated
   functions `describe_plan()` and `describe_optimized_plan()`. Those can be
   used in your project by following [this article](https://flir.etiennebacher.com/articles/sharing_rules#for-users).
@@ -75,6 +75,8 @@
   expression (#191).
 
 * Fix error in `count()` when it includes grouping variables (#193).
+
+* Passing `.` in an anonymous function in `across()` now works (#216).
 
 # tidypolars 0.13.0
 

--- a/R/utils-across.R
+++ b/R/utils-across.R
@@ -87,7 +87,9 @@ build_separate_calls <- function(.cols, .fns, .names, .data) {
       }
 
       arg <- sym(.cols[i])
-      list_calls[[nm]] <- expr_substitute(.fns[[j]], quote(.x), arg)
+      list_calls[[nm]] <- .fns[[j]] |>
+        expr_substitute(quote(.x), arg) |>
+        expr_substitute(quote(.), arg)
     }
   }
   unlist(list_calls)

--- a/tests/testthat/test-across-lazy.R
+++ b/tests/testthat/test-across-lazy.R
@@ -40,6 +40,22 @@ test_that("purrr-style function work", {
       cyl = cyl + 1
     )
   )
+
+  expect_equal_lazy(
+    mutate(
+      test,
+      across(.cols = contains("a"), ~ mean(.)),
+      cyl = cyl + 1
+    ),
+    mutate(
+      test,
+      drat = mean(drat),
+      am = mean(am),
+      gear = mean(gear),
+      carb = mean(carb),
+      cyl = cyl + 1
+    )
+  )
 })
 
 test_that("anonymous functions has to return a Polars expression", {

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -36,6 +36,22 @@ test_that("purrr-style function work", {
       cyl = cyl + 1
     )
   )
+
+  expect_equal(
+    mutate(
+      test,
+      across(.cols = contains("a"), ~ mean(.)),
+      cyl = cyl + 1
+    ),
+    mutate(
+      test,
+      drat = mean(drat),
+      am = mean(am),
+      gear = mean(gear),
+      carb = mean(carb),
+      cyl = cyl + 1
+    )
+  )
 })
 
 test_that("anonymous functions has to return a Polars expression", {


### PR DESCRIPTION
Fixes #215 