### PR TITLE
fix: Corner case of `filter()` in custom function with missing argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tidypolars
 Type: Package
 Title: More Efficient Tidyverse Code, Using Polars in the Background
-Version: 0.14.0
+Version: 0.14.0.9000
 Authors@R:
     c(person(given = "Etienne",
              family = "Bacher",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# tidypolars (development version)
+
+## Bug fixes
+
+* Fix a corner case when `filter()` was used in a custom function with missing
+  arguments (#220).
+
 # tidypolars 0.14.0
 
 * `tidypolars` requires `polars` >= 1.0.0. This release of `polars` contains

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -789,7 +789,6 @@ translate <- function(
 }
 
 get_user_defined_functions <- function(caller) {
-  # browser()
   x <- ls(caller)
   list_fns <- list()
   for (i in x) {
@@ -798,7 +797,7 @@ get_user_defined_functions <- function(caller) {
       warning = function(w) invisible(),
       error = function(e) NULL
     )
-    if (!is.null(foo) && is.function(foo)) {
+    if (!missing(foo) && !is.null(foo) && is.function(foo)) {
       list_fns[[i]] <- i
     }
   }

--- a/tests/testthat/test-utils_expr-lazy.R
+++ b/tests/testthat/test-utils_expr-lazy.R
@@ -68,4 +68,14 @@ test_that("error messages when error in known function is good", {
   )
 })
 
+test_that("doesn't error with missing variable in function call, #219", {
+  pl_iris <- pl$LazyFrame(x = 1)
+  # only errors with filter()
+  foobar <- function(x) {
+    pl_iris |> filter(x == 1)
+  }
+
+  expect_equal_lazy(foobar(), pl_iris)
+})
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-utils_expr.R
+++ b/tests/testthat/test-utils_expr.R
@@ -63,3 +63,13 @@ test_that("error messages when error in known function is good", {
     error = TRUE
   )
 })
+
+test_that("doesn't error with missing variable in function call, #219", {
+  pl_iris <- pl$DataFrame(x = 1)
+  # only errors with filter()
+  foobar <- function(x) {
+    pl_iris |> filter(x == 1)
+  }
+
+  expect_equal(foobar(), pl_iris)
+})


### PR DESCRIPTION
Fixes #219