### PR TITLE
fix: Correctly use argument `fixed` in `grepl()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * Fix a corner case when `filter()` was used in a custom function with missing
   arguments (#220).
 
+* In `grepl()`, the argument `fixed` is now used correctly (thanks @gernophil
+  for the report, #223).
+
 # tidypolars 0.14.0
 
 * `tidypolars` requires `polars` >= 1.0.0. This release of `polars` contains
@@ -34,7 +37,7 @@
     * `row_oriented` -> no replacement
   - in `write_ipc_polars()`:
     * `future` -> `compat_level`
-    
+
 * `fetch()` is deprecated, use `head()` before `collect()` instead (#194).
 
 * `group_keys()` now returns a `tibble` and not a `data.frame` anymore (#194).
@@ -43,7 +46,7 @@
   now error if some components go over their expected range, e.g. `month = 20`
   or `hour = 25`. Before, those functions were returning `NA` in this situation
   (#194).
-  
+
 * `summary()` returns an additional row for the 50% percentile (#194).
 
 ## New features

--- a/R/funs-string.R
+++ b/R/funs-string.R
@@ -1,6 +1,6 @@
 pl_grepl <- function(pattern, x, fixed = FALSE, ...) {
   if (isTRUE(fixed)) {
-    attr(x, "stringr_attr") <- "fixed"
+    attr(pattern, "stringr_attr") <- "fixed"
   }
   pl_str_detect_stringr(string = x, pattern = pattern, ...)
 }

--- a/tests/testthat/test-funs_string-lazy.R
+++ b/tests/testthat/test-funs_string-lazy.R
@@ -863,6 +863,7 @@ test_that("detect functions work", {
     x8 = c("Jane-saw-a-cat", "Jane-sat-down"),
     x9 = c(" Some text    with ws   ", "and more     white   space  "),
     x10 = c("Age_groups_0_4_years_Persons", "Age_groups_5_14_years_Persons"),
+    x11 = c("abc", "a."),
     n = 1:2
   )
   test <- as_polars_lf(test_df)
@@ -910,9 +911,9 @@ test_that("detect functions work", {
   )
 
   expect_equal_lazy(
-    mutate(test, foo = grepl(".", x5, fixed = TRUE)) |>
+    mutate(test, foo = grepl(".", x11, fixed = TRUE)) |>
       pull(foo),
-    mutate(test_df, foo = grepl(".", x5, fixed = TRUE)) |>
+    mutate(test_df, foo = grepl(".", x11, fixed = TRUE)) |>
       pull(foo)
   )
 

--- a/tests/testthat/test-funs_string.R
+++ b/tests/testthat/test-funs_string.R
@@ -859,6 +859,7 @@ test_that("detect functions work", {
     x8 = c("Jane-saw-a-cat", "Jane-sat-down"),
     x9 = c(" Some text    with ws   ", "and more     white   space  "),
     x10 = c("Age_groups_0_4_years_Persons", "Age_groups_5_14_years_Persons"),
+    x11 = c("abc", "a."),
     n = 1:2
   )
   test <- as_polars_df(test_df)
@@ -906,9 +907,9 @@ test_that("detect functions work", {
   )
 
   expect_equal(
-    mutate(test, foo = grepl(".", x5, fixed = TRUE)) |>
+    mutate(test, foo = grepl(".", x11, fixed = TRUE)) |>
       pull(foo),
-    mutate(test_df, foo = grepl(".", x5, fixed = TRUE)) |>
+    mutate(test_df, foo = grepl(".", x11, fixed = TRUE)) |>
       pull(foo)
   )
 


### PR DESCRIPTION
Fixes #221