### PR TITLE
fix: Better error message for unsupported arg `.drop` in `group_by()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 * Add partial support for `stringr::str_equal()` (#228).
 
+## Bug fixes
+
+* Better error message in `group_by()` for unsupported arg `.drop` (#230).
+
 # tidypolars 0.14.1
 
 * `tidypolars` requires `polars` >= 1.1.0 (#222).

--- a/R/groups.R
+++ b/R/groups.R
@@ -31,8 +31,15 @@ group_by.polars_data_frame <- function(
   .data,
   ...,
   maintain_order = FALSE,
-  .add = FALSE
+  .add = FALSE,
+  .drop = TRUE
 ) {
+  if (isFALSE(.drop)) {
+    cli_abort(
+      "{.pkg tidypolars} doesn't support {.code .drop = FALSE} in {.fn group_by}.",
+    )
+  }
+
   if (isTRUE(attributes(.data)$grp_type == "rowwise")) {
     cli_abort(
       c(

--- a/tests/testthat/_snaps/group_by.md
+++ b/tests/testthat/_snaps/group_by.md
@@ -1,0 +1,8 @@
+# Arg `.drop` is not supported in group_by()
+
+    Code
+      group_by(as_polars_df(iris), Species, .drop = FALSE)
+    Condition
+      Error in `group_by()`:
+      ! tidypolars doesn't support `.drop = FALSE` in `group_by()`.
+

--- a/tests/testthat/test-group_by-lazy.R
+++ b/tests/testthat/test-group_by-lazy.R
@@ -1,0 +1,14 @@
+### [GENERATED AUTOMATICALLY] Update test-group_by.R instead.
+
+Sys.setenv('TIDYPOLARS_TEST' = TRUE)
+
+test_that("Arg `.drop` is not supported in group_by()", {
+  expect_snapshot_lazy(
+    iris |>
+      as_polars_lf() |>
+      group_by(Species, .drop = FALSE),
+    error = TRUE
+  )
+})
+
+Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-group_by.R
+++ b/tests/testthat/test-group_by.R
@@ -1,0 +1,8 @@
+test_that("Arg `.drop` is not supported in group_by()", {
+  expect_snapshot(
+    iris |>
+      as_polars_df() |>
+      group_by(Species, .drop = FALSE),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
Fixes #201 