### PR TITLE
fix: Better error message when passing named expressions in `group_by()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,11 @@
 
 * Better error message in `group_by()` for unsupported argument `.drop` (#230).
 
+* Better error message in `group_by()` when passing named expressions in `...`.
+  `dplyr` supports those but it is more and more recommended to use the `.by` / 
+  `by` argument in individual functions rather than using `group_by()` and 
+  `ungroup()` (#238).
+  
 ## Other
 
 * New vignette "How to benchmark tidypolars" (#232).

--- a/R/groups.R
+++ b/R/groups.R
@@ -51,6 +51,7 @@ group_by.polars_data_frame <- function(
     )
   }
 
+  disallow_named_expressions(...)
   vars <- tidyselect_dots(.data, ...)
 
   if (isTRUE(.add)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -158,3 +158,15 @@ check_integerish <- function(x, name, allow_na = TRUE) {
     cli_abort("{.code {name}} must be integerish.")
   }
 }
+
+disallow_named_expressions <- function(...) {
+  if (!is.null(...names())) {
+    fn_name <- call_match(sys.call(sys.parent()), sys.function(sys.parent())) |>
+      call_name() |>
+      gsub("\\.polars_(data|lazy)_frame", "", x = _)
+    cli_abort(
+      "{.pkg tidypolars} doesn't support named expressions in {.fn {fn_name}}.",
+      call = caller_env()
+    )
+  }
+}

--- a/tests/testthat/_snaps/group_by-lazy.md
+++ b/tests/testthat/_snaps/group_by-lazy.md
@@ -6,3 +6,11 @@
       Error in `group_by()`:
       ! tidypolars doesn't support `.drop = FALSE` in `group_by()`.
 
+# group_by() doesn't support named expressions, #233
+
+    Code
+      current$collect()
+    Condition
+      Error in `group_by()`:
+      ! tidypolars doesn't support named expressions in `group_by()`.
+

--- a/tests/testthat/_snaps/group_by.md
+++ b/tests/testthat/_snaps/group_by.md
@@ -6,3 +6,11 @@
       Error in `group_by()`:
       ! tidypolars doesn't support `.drop = FALSE` in `group_by()`.
 
+# group_by() doesn't support named expressions, #233
+
+    Code
+      count(group_by(as_polars_df(iris), is_present = !is.na(Sepal.Length)))
+    Condition
+      Error in `group_by()`:
+      ! tidypolars doesn't support named expressions in `group_by()`.
+

--- a/tests/testthat/test-group_by-lazy.R
+++ b/tests/testthat/test-group_by-lazy.R
@@ -11,4 +11,14 @@ test_that("Arg `.drop` is not supported in group_by()", {
   )
 })
 
+test_that("group_by() doesn't support named expressions, #233", {
+  expect_snapshot_lazy(
+    iris |>
+      as_polars_lf() |>
+      group_by(is_present = !is.na(Sepal.Length)) |>
+      count(),
+    error = TRUE
+  )
+})
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-group_by.R
+++ b/tests/testthat/test-group_by.R
@@ -6,3 +6,13 @@ test_that("Arg `.drop` is not supported in group_by()", {
     error = TRUE
   )
 })
+
+test_that("group_by() doesn't support named expressions, #233", {
+  expect_snapshot(
+    iris |>
+      as_polars_df() |>
+      group_by(is_present = !is.na(Sepal.Length)) |>
+      count(),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
Related to (but doesn't fix) #233