### PR TITLE
fix: Better error message when passing named expressions in `count()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,8 +21,7 @@
   `by` argument in individual functions rather than using `group_by()` and 
   `ungroup()` (#238).
 
-* Better error message in `count()` when passing named expressions in `...` 
-  (#239).
+* Better error message in `count()` when passing named expressions in `...` (#239).
   
 ## Other
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@
   `dplyr` supports those but it is more and more recommended to use the `.by` / 
   `by` argument in individual functions rather than using `group_by()` and 
   `ungroup()` (#238).
+
+* Better error message in `count()` when passing named expressions in `...` 
+  (#239).
   
 ## Other
 

--- a/R/count.R
+++ b/R/count.R
@@ -39,6 +39,7 @@ count.polars_data_frame <- function(
   mo <- attributes(x)$maintain_grp_order
   is_grouped <- !is.null(grps)
 
+  disallow_named_expressions(...)
   vars <- tidyselect_dots(x, ...)
   vars <- c(grps, vars)
   out <- count_(x, vars, sort = sort, name = name, new_col = FALSE)

--- a/tests/testthat/_snaps/count-lazy.md
+++ b/tests/testthat/_snaps/count-lazy.md
@@ -1,0 +1,8 @@
+# group_by() doesn't support named expressions, #233
+
+    Code
+      current$collect()
+    Condition
+      Error in `group_by()`:
+      ! tidypolars doesn't support named expressions in `group_by()`.
+

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -1,0 +1,8 @@
+# group_by() doesn't support named expressions, #233
+
+    Code
+      count(group_by(as_polars_df(iris), is_present = !is.na(Sepal.Length)))
+    Condition
+      Error in `group_by()`:
+      ! tidypolars doesn't support named expressions in `group_by()`.
+

--- a/tests/testthat/test-count-lazy.R
+++ b/tests/testthat/test-count-lazy.R
@@ -188,4 +188,14 @@ test_that("count() and add_count() explicitly do not support 'wt'", {
   )
 })
 
+test_that("group_by() doesn't support named expressions, #233", {
+  expect_snapshot_lazy(
+    iris |>
+      as_polars_lf() |>
+      group_by(is_present = !is.na(Sepal.Length)) |>
+      count(),
+    error = TRUE
+  )
+})
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -183,3 +183,13 @@ test_that("count() and add_count() explicitly do not support 'wt'", {
     }
   )
 })
+
+test_that("group_by() doesn't support named expressions, #233", {
+  expect_snapshot(
+    iris |>
+      as_polars_df() |>
+      group_by(is_present = !is.na(Sepal.Length)) |>
+      count(),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
Fixes #233 