### PR TITLE
fix: `join_where()` when common cols are all in the conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,9 @@
 
 * Better error message in `count()` when passing named expressions in `...` (#239).
 
+* Fix bug in `join_where()` when all common column names between two DataFrames
+  are used in the join conditions (#254)
+
 ## Documentation
 
 * New vignette "How to benchmark tidypolars" (#232).

--- a/R/join.R
+++ b/R/join.R
@@ -556,13 +556,13 @@ eval_inequality_join <- function(x, y, how, by, suffix) {
   if (length(to_drop) > 0) {
     res <- res$drop(!!!to_drop)
   }
+  # Only keep common columns that were involved in inequality joins, otherwise
+  # they just don't have a duplicate in the output
+  common_cols <- Filter(
+    function(x) paste0(x, suffix[2]) %in% names(res),
+    common_cols
+  )
   if (length(common_cols) > 0) {
-    # Only keep common columns that were involved in inequality joins, otherwise
-    # they just don't have a duplicate in the output
-    common_cols <- Filter(
-      function(x) paste0(x, suffix[2]) %in% names(res),
-      common_cols
-    )
     new_cols <- as.list(paste0(common_cols, suffix[1]))
     names(new_cols) <- common_cols
     res <- res$rename(!!!new_cols)

--- a/tests/testthat/test-join_inequality-lazy.R
+++ b/tests/testthat/test-join_inequality-lazy.R
@@ -172,7 +172,8 @@ test_that("'overlaps' helper works", {
   }
 })
 
-test_that("", {
+test_that("all common columns are used in join conditions", {
+  # https://stackoverflow.com/questions/79782259/tidypolars-strange-error-with-inequality-join
   x <- tibble(
     id = c(1, 1, 2, 2),
     t = as.POSIXct("2023-05-02 12:00") %m+% months(0:3)

--- a/tests/testthat/test-join_inequality-lazy.R
+++ b/tests/testthat/test-join_inequality-lazy.R
@@ -172,4 +172,28 @@ test_that("'overlaps' helper works", {
   }
 })
 
+test_that("", {
+  x <- tibble(
+    id = c(1, 1, 2, 2),
+    t = as.POSIXct("2023-05-02 12:00") %m+% months(0:3)
+  )
+  x_pl <- as_polars_lf(x)
+
+  y <- tibble(
+    id = c(1, 1, 2, 2),
+    start = as.POSIXct("2023-05-01 12:00") %m+% months(0:3),
+    end = as.POSIXct("2023-05-03 12:00") %m+% months(0:3),
+  )
+  y_pl <- as_polars_lf(y)
+
+  expect_identical(
+    x_pl |>
+      inner_join(y_pl, by = join_by(id, between(t, start, end))) |>
+      as_tibble(),
+    x |>
+      inner_join(y, by = join_by(id, between(t, start, end))) |>
+      as_tibble()
+  )
+})
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-join_inequality.R
+++ b/tests/testthat/test-join_inequality.R
@@ -168,7 +168,8 @@ test_that("'overlaps' helper works", {
   }
 })
 
-test_that("", {
+test_that("all common columns are used in join conditions", {
+  # https://stackoverflow.com/questions/79782259/tidypolars-strange-error-with-inequality-join
   x <- tibble(
     id = c(1, 1, 2, 2),
     t = as.POSIXct("2023-05-02 12:00") %m+% months(0:3)

--- a/tests/testthat/test-join_inequality.R
+++ b/tests/testthat/test-join_inequality.R
@@ -167,3 +167,27 @@ test_that("'overlaps' helper works", {
     )
   }
 })
+
+test_that("", {
+  x <- tibble(
+    id = c(1, 1, 2, 2),
+    t = as.POSIXct("2023-05-02 12:00") %m+% months(0:3)
+  )
+  x_pl <- as_polars_lf(x)
+
+  y <- tibble(
+    id = c(1, 1, 2, 2),
+    start = as.POSIXct("2023-05-01 12:00") %m+% months(0:3),
+    end = as.POSIXct("2023-05-03 12:00") %m+% months(0:3),
+  )
+  y_pl <- as_polars_lf(y)
+
+  expect_identical(
+    x_pl |>
+      inner_join(y_pl, by = join_by(id, between(t, start, end))) |>
+      as_tibble(),
+    x |>
+      inner_join(y, by = join_by(id, between(t, start, end))) |>
+      as_tibble()
+  )
+})


### PR DESCRIPTION
https://stackoverflow.com/questions/79782259/tidypolars-strange-error-with-inequality-join