### PR TITLE
fix: `%in%` retains `NA`, except when the RHS only contains `NA`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,9 @@
 * Better error message in `count()` when passing named expressions in `...` (#239).
 
 * Fix bug in `join_where()` when all common column names between two DataFrames
-  are used in the join conditions (#254)
+  are used in the join conditions (#254).
+
+* Using `%in%` with `NA` now retains the `NA` in the data (#256).
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,8 @@
 * Fix bug in `join_where()` when all common column names between two DataFrames
   are used in the join conditions (#254).
 
-* Using `%in%` with `NA` now retains the `NA` in the data (#256).
+* Using `%in%` with `NA` now retains the `NA` in the data. Using `%in% NA` will
+  error (#256).
 
 ## Documentation
 

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -495,7 +495,7 @@ translate <- function(
               if (is.list(rhs)) {
                 rhs <- unlist(rhs)
               }
-              lhs$is_in(rhs)
+              lhs$is_in(rhs, nulls_equal = TRUE)
             },
             error = identity
           )

--- a/tests/testthat/test-filter-lazy.R
+++ b/tests/testthat/test-filter-lazy.R
@@ -137,6 +137,24 @@ test_that("%in% works", {
   )
 })
 
+test_that("%in% works with NA", {
+  test <- data.frame(x = c(1, 2, NA))
+  test_pl <- as_polars_lf(test)
+
+  expect_equal_lazy(
+    test |> filter(x %in% c(1, NA)),
+    test_pl |> filter(x %in% c(1, NA))
+  )
+  # TODO: ideally this should work, but I think it's going to be tricky because
+  # we need to know the dtype of the LHS, which is not easy (or possible?).
+  # Maybe throw a custom error since this should only happen when the rhs is NA
+  # only?
+  # expect_equal_lazy(
+  #   test |> filter(x %in% NA),
+  #   test_pl |> filter(x %in% NA)
+  # )
+})
+
 test_that("between() works", {
   pl_iris <- as_polars_lf(iris)
 

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -133,6 +133,24 @@ test_that("%in% works", {
   )
 })
 
+test_that("%in% works with NA", {
+  test <- data.frame(x = c(1, 2, NA))
+  test_pl <- as_polars_df(test)
+
+  expect_equal(
+    test |> filter(x %in% c(1, NA)),
+    test_pl |> filter(x %in% c(1, NA))
+  )
+  # TODO: ideally this should work, but I think it's going to be tricky because
+  # we need to know the dtype of the LHS, which is not easy (or possible?).
+  # Maybe throw a custom error since this should only happen when the rhs is NA
+  # only?
+  # expect_equal(
+  #   test |> filter(x %in% NA),
+  #   test_pl |> filter(x %in% NA)
+  # )
+})
+
 test_that("between() works", {
   pl_iris <- as_polars_df(iris)
 

--- a/tests/testthat/test-join_inequality.R
+++ b/tests/testthat/test-join_inequality.R
@@ -174,14 +174,14 @@ test_that("all common columns are used in join conditions", {
     id = c(1, 1, 2, 2),
     t = as.POSIXct("2023-05-02 12:00") %m+% months(0:3)
   )
-  x_pl <- as_polars_lf(x)
+  x_pl <- as_polars_df(x)
 
   y <- tibble(
     id = c(1, 1, 2, 2),
     start = as.POSIXct("2023-05-01 12:00") %m+% months(0:3),
     end = as.POSIXct("2023-05-03 12:00") %m+% months(0:3),
   )
-  y_pl <- as_polars_lf(y)
+  y_pl <- as_polars_df(y)
 
   expect_identical(
     x_pl |>


### PR DESCRIPTION
Fixes #255