### PR TITLE
fix: remove unused `Imports` field item `utils`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Imports:
     rlang,
     tidyr,
     tidyselect,
-    utils,
     vctrs
 Suggests:
     arrow,


### PR DESCRIPTION
R CMD check says:

```
* checking dependencies in R code ... NOTE
Namespace in Imports field not imported from: ‘utils’
  All declared Imports should be used.
```