### PR TITLE
refactor: Fix lint errors in Jarl 0.3.0

### DIFF
--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -434,7 +434,7 @@ translate <- function(
           expr[[1]] <- NULL
           if (
             # we may pass a named vector in str_replace_all() for instance
-            !is.null(names(expr)) |
+            !is.null(names(expr)) ||
               # we may pass a vector of column names
               any(vapply(expr, is.symbol, FUN.VALUE = logical(1L)))
           ) {
@@ -745,7 +745,10 @@ translate <- function(
           }
           # Only suggest opening an issue for functions coming from other pkgs,
           # not for custom functions.
-          if (!is.null(fn_names$pkg) || grepl("::", fn_names$orig_name)) {
+          if (
+            !is.null(fn_names$pkg) ||
+              grepl("::", fn_names$orig_name, fixed = TRUE)
+          ) {
             msg <- c(
               msg,
               i = "You can ask for it to be translated here: {.url https://github.com/etiennebacher/tidypolars/issues}."
@@ -926,7 +929,7 @@ add_pkg_suffix <- function(name, known_ops, user_defined) {
 
   fn <- name
 
-  if (grepl("::", fn)) {
+  if (grepl("::", fn, fixed = TRUE)) {
     pkg <- gsub("::.*", "", fn)
     fn <- gsub(".*::", "", fn)
   } else {
@@ -944,7 +947,7 @@ add_pkg_suffix <- function(name, known_ops, user_defined) {
     name_to_eval <- paste0("pl_", fn, "_", pkg)
   }
 
-  if (grepl("::", name)) {
+  if (grepl("::", name, fixed = TRUE)) {
     # Don't store the pkg name if it's explicitly specified.
     # Don't do this too early because we need pkg when building the function to
     # eval.

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -92,7 +92,7 @@ expect_snapshot_lazy <- function(current, ...) {
 
 test_this_file <- function() {
   file <- rstudioapi::getSourceEditorContext()$path
-  if (!grepl("testthat/", file)) {
+  if (!grepl("testthat/", file, fixed = TRUE)) {
     message("Must run this when the active window is a test file.")
     return(invisible())
   }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -6,7 +6,7 @@ library(tidyr)
 library(tools)
 
 lf <- list.files(test_path(), pattern = "^test")
-eager <- lf[grep("lazy", lf, invert = TRUE)]
+eager <- lf[grep("lazy", lf, invert = TRUE, fixed = TRUE)]
 
 exceptions <- c(
   "test-benchmark.R",
@@ -33,7 +33,7 @@ for (i in eager) {
   out <- gsub("as_polars_df\\(", "as_polars_lf(", out)
   out <- gsub("expect_equal\\(", "expect_equal_lazy(", out)
   out <- gsub("expect_error\\(", "expect_error_lazy(", out)
-  out <- gsub("expect_snapshot", "expect_snapshot_lazy", out)
+  out <- gsub("expect_snapshot", "expect_snapshot_lazy", out, fixed = TRUE)
   out <- paste0(
     "### [GENERATED AUTOMATICALLY] Update ",
     i,


### PR DESCRIPTION
jarl 0.3.0 introduced `vector_logic` and `fixed_regex` checks, which caused the current jarl-check CI to fail. I fixed these issues by:
- Added six `fixed = TRUE`
- Replace ` | ` with ` || ` in an `if()`