### PR TITLE
Update test snapshots to make all tests pass

### DIFF
--- a/tests/testthat/_snaps/partitioned_output.md
+++ b/tests/testthat/_snaps/partitioned_output.md
@@ -69,18 +69,18 @@
       <scrubbed>
       +-- am=0.0
       |   +-- cyl=4.0
-      |   |   \-- 00000000.parquet
+      |   |   \-- 0.parquet
       |   +-- cyl=6.0
-      |   |   \-- 00000000.parquet
+      |   |   \-- 0.parquet
       |   \-- cyl=8.0
-      |       \-- 00000000.parquet
+      |       \-- 0.parquet
       \-- am=1.0
           +-- cyl=4.0
-          |   \-- 00000000.parquet
+          |   \-- 0.parquet
           +-- cyl=6.0
-          |   \-- 00000000.parquet
+          |   \-- 0.parquet
           \-- cyl=8.0
-              \-- 00000000.parquet
+              \-- 0.parquet
 
 # partition_by_max_size() works
 

--- a/tests/testthat/_snaps/pivot_wider.md
+++ b/tests/testthat/_snaps/pivot_wider.md
@@ -15,8 +15,6 @@
       Error in `data$pivot()`:
       ! Evaluation failed in `$pivot()`.
       Caused by error:
-      ! Evaluation failed in `$collect()`.
-      Caused by error:
       ! Duplicated column(s): could not create a new DataFrame: column with name 'a' has more than one occurrence
 
 # `names_from` must be supplied if `name` isn't in data
@@ -61,9 +59,7 @@
       Error in `data$pivot()`:
       ! Evaluation failed in `$pivot()`.
       Caused by error:
-      ! Evaluation failed in `$collect()`.
-      Caused by error:
-      ! at least one key is required in a group_by operation
+      ! index cannot be zero length
 
 ---
 
@@ -73,9 +69,7 @@
       Error in `data$pivot()`:
       ! Evaluation failed in `$pivot()`.
       Caused by error:
-      ! Evaluation failed in `$collect()`.
-      Caused by error:
-      ! at least one key is required in a group_by operation
+      ! index cannot be zero length
 
 # dots must be empty
 


### PR DESCRIPTION
## Summary

These snapshot updates make all tests pass.
- Update `partitioned_output` snapshot to reflect new parquet file naming format (`0.parquet` instead of `00000000.parquet`)
- Update `pivot_wider` error message snapshots to match polars error formatting