### PR TITLE
docs: add PR title conventions to `CONTRIBUTING.md`

### DIFF
--- a/.github/CONTRIBUTING.Rmd
+++ b/.github/CONTRIBUTING.Rmd
@@ -117,3 +117,18 @@ some tests in the related file in `tests/testthat`.
 Note that you only need to edit the file with `test_<function name>.R`. Files
 ending with `_lazy.R` are automatically generated. Use `devtools::load_all()`
 and `test_all_tidypolars()` to run the test suite.
+
+### PR title
+
+Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+for PR titles, meaning that your PR titles must start with "feat:", "fix:",
+or another appropriate name (see the linked documentation). For example:
+
+* `feat`: A new feature.
+* `fix`: A bug fix.
+* `docs`: Documentation only changes.
+* `test`: Adding missing tests or correcting existing tests.
+* `chore`: Changes to the build process or auxiliary tools and libraries.
+* `refactor`: A code change that neither fixes a bug nor adds a feature.
+
+See the [list of previous PRs](https://github.com/etiennebacher/tidypolars/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aclosed) for some examples.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -169,3 +169,18 @@ No matter the type of function you added or modified, you should only write
 tests on Polars DataFrames. Those will be automatically modified when running 
 the tests to run on LazyFrames as well (for instance, the file 
 `test-drop_na-lazy.R` will be automatically generated). 
+
+### PR title
+
+Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+for PR titles, meaning that your PR titles must start with "feat:", "fix:",
+or another appropriate name (see the linked documentation). For example:
+
+- `feat`: A new feature.
+- `fix`: A bug fix.
+- `docs`: Documentation only changes.
+- `test`: Adding missing tests or correcting existing tests.
+- `chore`: Changes to the build process or auxiliary tools and libraries.
+- `refactor`: A code change that neither fixes a bug nor adds a feature.
+
+See the [list of previous PRs](https://github.com/etiennebacher/tidypolars/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aclosed) for some examples.


### PR DESCRIPTION
Adds a section to `CONTRIBUTING.md` outlining the Conventional Commits for PR titles. This matches the contributing guide in other projects such as [jarl](https://github.com/etiennebacher/jarl/blob/main/docs/contributing.md#pr-title), and will help new contributors like me make better PRs.

I don't know what is the relationship between `CONTRIBUTING.md` and `CONTRIBUTING.Rmd`. Please correct me if I modified them wrongly.