### PR TITLE
ci: Try to fix CI failures on Windows

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -45,6 +45,8 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # TODO: this shouldn't be necessary but it prevents occasional failures on
+      # Windows, #291
       TESTTHAT_CPUS: ${{ matrix.os == 'windows-latest' && '1' || '2' }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This change limits `testthat` to 1 Process on Windows and gets a success rate of more than 85%. Linux and macOS are not affected.
 #290 https://github.com/etiennebacher/tidypolars/issues/290#issuecomment-3697377788