### PR TITLE
fix: `.keep` in `mutate()` doesn't keep columns correctly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 * Added support for `%notin%` (#349).
 
+## Bug fixes
+
+- Fix `.keep` in `mutate()` to avoid accidentally deleting created columns,
+  modified columns and grouping columns (@Yousa-Mirage, #353).
+
 # tidypolars 0.18.0
 
 `tidypolars` requires `polars` >= 1.10.0.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ## Bug fixes
 
-- Fix `.keep` in `mutate()` to avoid accidentally droping columns (@Yousa-Mirage, #353).
+- Fix `.keep` in `mutate()` to avoid accidentally dropping columns (@Yousa-Mirage, #353).
 
 # tidypolars 0.18.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,7 @@
 
 ## Bug fixes
 
-- Fix `.keep` in `mutate()` to avoid accidentally deleting created columns,
-  modified columns and grouping columns (@Yousa-Mirage, #353).
+- Fix `.keep` in `mutate()` to avoid accidentally droping columns (@Yousa-Mirage, #353).
 
 # tidypolars 0.18.0
 

--- a/R/mutate.R
+++ b/R/mutate.R
@@ -123,11 +123,13 @@ mutate.polars_data_frame <- function(
 
   used <- c()
   orig_names <- names(.data)
+  mutated_vars <- c()
 
   for (i in seq_along(polars_exprs)) {
     sub <- polars_exprs[[i]]
     to_drop <- names(empty_elems(sub))
     sub <- compact(sub)
+    mutated_vars <- c(mutated_vars, names(sub))
 
     used <- c(
       used,
@@ -159,15 +161,17 @@ mutate.polars_data_frame <- function(
   }
 
   if (.keep != "all") {
-    new_vars <- setdiff(names(.data), orig_names)
+    current_names <- names(.data)
+    always_keep <- unique(c(grps, mutated_vars))
     not_used <- setdiff(orig_names, used)
-    not_used <- setdiff(not_used, grps)
+    not_used <- setdiff(not_used, always_keep)
+    used <- setdiff(used, always_keep)
     if (.keep == "used") {
-      .data <- .data$drop(not_used)
+      .data <- .data$drop(intersect(not_used, current_names))
     } else if (.keep == "unused") {
-      .data <- .data$drop(used)
+      .data <- .data$drop(intersect(used, current_names))
     } else if (.keep == "none") {
-      .data <- .data$drop(c(not_used, used))
+      .data <- .data$drop(intersect(c(not_used, used), current_names))
     }
   }
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -38,7 +38,6 @@ deprecations
 devtools
 downup
 dplyr
-droping
 dtypes
 equalities
 gcp

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -38,6 +38,7 @@ deprecations
 devtools
 downup
 dplyr
+droping
 dtypes
 equalities
 gcp

--- a/tests/testthat/test-mutate-lazy.R
+++ b/tests/testthat/test-mutate-lazy.R
@@ -390,6 +390,84 @@ test_that("argument .keep works", {
   )
 })
 
+test_that("argument .keep preserves overwritten columns", {
+  test_df <- tibble(
+    x = c(1, 2, 3),
+    y = c(4, 5, 6)
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    mutate(test_pl, x = x + 1, .keep = "unused"),
+    mutate(test_df, x = x + 1, .keep = "unused")
+  )
+
+  expect_equal_lazy(
+    mutate(test_pl, x = y + 1, .keep = "used"),
+    mutate(test_df, x = y + 1, .keep = "used")
+  )
+
+  expect_equal_lazy(
+    mutate(test_pl, x = 1, .keep = "used"),
+    mutate(test_df, x = 1, .keep = "used")
+  )
+
+  expect_equal_lazy(
+    mutate(test_pl, x = x + 1, .keep = "none"),
+    mutate(test_df, x = x + 1, .keep = "none")
+  )
+})
+
+test_that("argument .keep works when columns are removed", {
+  test_df <- tibble(
+    x = c(1, 2, 3),
+    y = c(4, 5, 6),
+    z = c(7, 8, 9)
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    mutate(test_pl, y = NULL, new = x + z, .keep = "used"),
+    mutate(test_df, y = NULL, new = x + z, .keep = "used")
+  )
+
+  expect_equal_lazy(
+    mutate(test_pl, new = x + y, y = NULL, .keep = "unused"),
+    mutate(test_df, new = x + y, y = NULL, .keep = "unused")
+  )
+
+  expect_equal_lazy(
+    mutate(test_pl, y = NULL, new = x + z, .keep = "none"),
+    mutate(test_df, y = NULL, new = x + z, .keep = "none")
+  )
+})
+
+test_that("argument .keep preserves overwritten grouping columns", {
+  test_df <- tibble(
+    x = c(1, 2, 3),
+    y = c(4, 5, 6)
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |>
+      group_by(x) |>
+      mutate(x = x + 1, .keep = "unused") |>
+      ungroup(),
+    test_df |>
+      group_by(x) |>
+      mutate(x = x + 1, .keep = "unused") |>
+      ungroup()
+  )
+
+  expect_equal_lazy(
+    test_pl |>
+      mutate(x = x + 1, .by = x, .keep = "none"),
+    test_df |>
+      mutate(x = x + 1, .by = x, .keep = "none")
+  )
+})
+
 test_that("works with a local variable defined in a function", {
   foobar <- function(x) {
     local_var <- "a"

--- a/tests/testthat/test-mutate.R
+++ b/tests/testthat/test-mutate.R
@@ -386,6 +386,84 @@ test_that("argument .keep works", {
   )
 })
 
+test_that("argument .keep preserves overwritten columns", {
+  test_df <- tibble(
+    x = c(1, 2, 3),
+    y = c(4, 5, 6)
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    mutate(test_pl, x = x + 1, .keep = "unused"),
+    mutate(test_df, x = x + 1, .keep = "unused")
+  )
+
+  expect_equal(
+    mutate(test_pl, x = y + 1, .keep = "used"),
+    mutate(test_df, x = y + 1, .keep = "used")
+  )
+
+  expect_equal(
+    mutate(test_pl, x = 1, .keep = "used"),
+    mutate(test_df, x = 1, .keep = "used")
+  )
+
+  expect_equal(
+    mutate(test_pl, x = x + 1, .keep = "none"),
+    mutate(test_df, x = x + 1, .keep = "none")
+  )
+})
+
+test_that("argument .keep works when columns are removed", {
+  test_df <- tibble(
+    x = c(1, 2, 3),
+    y = c(4, 5, 6),
+    z = c(7, 8, 9)
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    mutate(test_pl, y = NULL, new = x + z, .keep = "used"),
+    mutate(test_df, y = NULL, new = x + z, .keep = "used")
+  )
+
+  expect_equal(
+    mutate(test_pl, new = x + y, y = NULL, .keep = "unused"),
+    mutate(test_df, new = x + y, y = NULL, .keep = "unused")
+  )
+
+  expect_equal(
+    mutate(test_pl, y = NULL, new = x + z, .keep = "none"),
+    mutate(test_df, y = NULL, new = x + z, .keep = "none")
+  )
+})
+
+test_that("argument .keep preserves overwritten grouping columns", {
+  test_df <- tibble(
+    x = c(1, 2, 3),
+    y = c(4, 5, 6)
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |>
+      group_by(x) |>
+      mutate(x = x + 1, .keep = "unused") |>
+      ungroup(),
+    test_df |>
+      group_by(x) |>
+      mutate(x = x + 1, .keep = "unused") |>
+      ungroup()
+  )
+
+  expect_equal(
+    test_pl |>
+      mutate(x = x + 1, .by = x, .keep = "none"),
+    test_df |>
+      mutate(x = x + 1, .by = x, .keep = "none")
+  )
+})
+
 test_that("works with a local variable defined in a function", {
   foobar <- function(x) {
     local_var <- "a"


### PR DESCRIPTION
fix #353 