### PR TITLE
feat: add time zone support for datetime parsing functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Added support for `%notin%` (#349).
 * Added support for `.before` and `.after` in `mutate()` (@Yousa-Mirage, #357).
 * Added support for `as.integer()` (#360).
+* Added time zone support for datetime parsing functions (@Yousa-Mirage, #364).
 
 ## Bug fixes
 
@@ -14,7 +15,8 @@
   columns (@Yousa-Mirage, #355).
 * Fix `relocate()` to handle `<tidy-select>` helpers consistently with `dplyr`
   (@Yousa-Mirage, #357).
-* Using the `tz` argument in `strptime()` no longer errors (@dejse, #361)
+* Using the `tz` argument in `strptime()` no longer errors (@dejse, @Yousa-Mirage,
+  #361)
 
 ## Bug fixes
 

--- a/R/funs-date.R
+++ b/R/funs-date.R
@@ -3,19 +3,43 @@
 
 # Date/time parsing --------------------------------------
 
-pl_ymd_lubridate <- function(x, ...) {
-  check_empty_dots(...)
+datetime_dtype_for_parsing <- function(tz, time_unit = "us") {
+  tz <- polars_expr_to_r(tz)
+
+  if (is.null(tz) || identical(tz, "")) {
+    tz <- Sys.timezone()
+  }
+
+  tz <- check_timezone(tz, empty_allowed = FALSE)
+  pl$Datetime(time_unit, time_zone = tz)
+}
+
+pl_ymd_lubridate <- function(x, tz = NULL, ...) {
   # I can't specify a particular format: lubridate::ymd() can detect "2009/01/01"
   # and "2009-01-01" for example. I have to rely on polars' guessing, even if
   # it is less performant
-  x$str$strptime(pl$Date, format = NULL, strict = FALSE)
+
+  check_empty_dots(...)
+  if (is.null(tz)) {
+    return(x$str$strptime(pl$Date, format = NULL, strict = FALSE))
+  }
+
+  x$str$strptime(
+    dtype = datetime_dtype_for_parsing(tz, time_unit = "ms"),
+    format = NULL,
+    strict = FALSE
+  )
 }
 
 pl_ydm_lubridate <- pl_mdy_lubridate <- pl_myd_lubridate <- pl_dmy_lubridate <- pl_dym_lubridate <- pl_ym_lubridate <- pl_my_lubridate <- pl_ymd_lubridate
 
-pl_ymd_hms_lubridate <- function(x, ...) {
+pl_ymd_hms_lubridate <- function(x, tz = "UTC", ...) {
   check_empty_dots(...)
-  x$str$strptime(pl$Datetime("ms"), format = NULL, strict = FALSE)
+  x$str$strptime(
+    datetime_dtype_for_parsing(tz, time_unit = "ms"),
+    format = NULL,
+    strict = FALSE
+  )
 }
 
 # Setting/getting/rounding --------------------------------------
@@ -314,11 +338,7 @@ pl_with_tz_lubridate <- function(time, tzone = "UTC", ...) {
 pl_strptime <- function(string, format, tz = "", ...) {
   check_empty_dots(...)
   format <- polars_expr_to_r(format)
-  tz <- polars_expr_to_r(tz)
-  if (identical(tz, "")) {
-    tz <- Sys.timezone()
-  }
-  dtype <- pl$Datetime("us", time_zone = tz)
+  dtype <- datetime_dtype_for_parsing(tz, time_unit = "us")
   string$cast(pl$String)$str$strptime(
     dtype = dtype,
     format = format,

--- a/R/funs-date.R
+++ b/R/funs-date.R
@@ -4,8 +4,6 @@
 # Date/time parsing --------------------------------------
 
 datetime_dtype_for_parsing <- function(tz, time_unit = "us") {
-  tz <- polars_expr_to_r(tz)
-
   if (is.null(tz) || identical(tz, "")) {
     tz <- Sys.timezone()
   }
@@ -338,7 +336,22 @@ pl_with_tz_lubridate <- function(time, tzone = "UTC", ...) {
 pl_strptime <- function(string, format, tz = "", ...) {
   check_empty_dots(...)
   format <- polars_expr_to_r(format)
-  dtype <- datetime_dtype_for_parsing(tz, time_unit = "us")
+
+  if (is.null(tz)) {
+    cli_abort("`tz` must be a time zone name, not `NULL`.")
+  }
+
+  if (identical(tz, "")) {
+    tz_env <- Sys.getenv("TZ")
+    dtype <- if (identical(tz_env, "")) {
+      pl$Datetime("us")
+    } else {
+      datetime_dtype_for_parsing(tz_env, time_unit = "us")
+    }
+  } else {
+    dtype <- datetime_dtype_for_parsing(tz, time_unit = "us")
+  }
+
   string$cast(pl$String)$str$strptime(
     dtype = dtype,
     format = format,

--- a/R/funs-date.R
+++ b/R/funs-date.R
@@ -338,7 +338,7 @@ pl_strptime <- function(string, format, tz = "", ...) {
   format <- polars_expr_to_r(format)
 
   if (is.null(tz)) {
-    cli_abort("`tz` must be a time zone name, not `NULL`.")
+    cli_abort("{.arg tz} must be a time zone name, not {.code NULL}.")
   }
 
   if (identical(tz, "")) {

--- a/tests/testthat/_snaps/funs_date-lazy.md
+++ b/tests/testthat/_snaps/funs_date-lazy.md
@@ -34,6 +34,24 @@
       ! Error while running function `wday()` in Polars.
       x `week_start` must be a whole number, not the string "Monday".
 
+# strptime() works
+
+    Code
+      current$collect()
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `strptime()` in Polars.
+      x Unrecognized time zone: NULL
+
+---
+
+    Code
+      current$collect()
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `strptime()` in Polars.
+      x Unrecognized time zone: "Not/A_Zone"
+
 # errors for durations
 
     Code

--- a/tests/testthat/_snaps/funs_date-lazy.md
+++ b/tests/testthat/_snaps/funs_date-lazy.md
@@ -52,6 +52,33 @@
       ! Error while running function `strptime()` in Polars.
       x Unrecognized time zone: "Not/A_Zone"
 
+# make_datetime() works
+
+    Code
+      current$collect()
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `make_datetime()` in Polars.
+      x Evaluation failed in `$datetime()`.
+
+# ISOdatetime() works
+
+    Code
+      current$collect()
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `ISOdatetime()` in Polars.
+      x Evaluation failed in `$datetime()`.
+
+# now() errors on invalid timezones
+
+    Code
+      current$collect()
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `now()` in Polars.
+      x Evaluation failed.
+
 # errors for durations
 
     Code

--- a/tests/testthat/_snaps/funs_date.md
+++ b/tests/testthat/_snaps/funs_date.md
@@ -52,6 +52,33 @@
       ! Error while running function `strptime()` in Polars.
       x Unrecognized time zone: "Not/A_Zone"
 
+# make_datetime() works
+
+    Code
+      mutate(test_pl, foo = make_datetime(year = 2020, month = 1, day = 2, tz = "Not/A_Zone"))
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `make_datetime()` in Polars.
+      x Evaluation failed in `$datetime()`.
+
+# ISOdatetime() works
+
+    Code
+      mutate(test_pl, foo = ISOdatetime(year = 2020, month = 1, day = 2, tz = "Not/A_Zone"))
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `ISOdatetime()` in Polars.
+      x Evaluation failed in `$datetime()`.
+
+# now() errors on invalid timezones
+
+    Code
+      suppressWarnings(mutate(test_pl, foo = now(tzone = "Not/A_Zone")))
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `now()` in Polars.
+      x Evaluation failed.
+
 # errors for durations
 
     Code

--- a/tests/testthat/_snaps/funs_date.md
+++ b/tests/testthat/_snaps/funs_date.md
@@ -34,6 +34,24 @@
       ! Error while running function `wday()` in Polars.
       x `week_start` must be a whole number, not the string "Monday".
 
+# strptime() works
+
+    Code
+      mutate(test_pl, foo = strptime(somedate, "%b %d %Y", tz = NULL))
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `strptime()` in Polars.
+      x Unrecognized time zone: NULL
+
+---
+
+    Code
+      mutate(test_pl, foo = strptime(somedate, "%b %d %Y", tz = "Not/A_Zone"))
+    Condition
+      Error in `mutate()`:
+      ! Error while running function `strptime()` in Polars.
+      x Unrecognized time zone: "Not/A_Zone"
+
 # errors for durations
 
     Code

--- a/tests/testthat/test-funs_date-lazy.R
+++ b/tests/testthat/test-funs_date-lazy.R
@@ -168,7 +168,12 @@ test_that("strptime() works", {
   expect_equal_lazy(
     test_pl |> mutate(foo = strptime(somedate, "%b %d %Y")),
     test_df |>
-      mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y")))
+      mutate(
+        foo = as.POSIXct(
+          strptime(somedate, "%b %d %Y"),
+          tz = Sys.timezone()
+        )
+      )
   )
 
   # Polars converts to POSIXct and not to POSIXlt
@@ -213,6 +218,38 @@ test_that("strptime() works", {
       mutate(
         foo = as.POSIXct(strptime(TRUE, "%Y-%m-%d %H:%M:%S", tz = "UTC"))
       )
+  )
+})
+
+test_that("date parsers respect timezone arguments", {
+  test_df <- tibble(
+    value = c("2020-01-02", NA)
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    mutate(test_pl, out = ymd(value, tz = "UTC")) |> pull(out),
+    mutate(test_df, out = ymd(value, tz = "UTC")) |> pull(out)
+  )
+  expect_equal_lazy(
+    mutate(test_pl, out = ymd(value, tz = "America/New_York")) |> pull(out),
+    mutate(test_df, out = ymd(value, tz = "America/New_York")) |> pull(out)
+  )
+})
+
+test_that("ymd_hms() respects timezone arguments", {
+  test_df <- tibble(
+    value = c("2020-01-02 12:34:56", NA)
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    mutate(test_pl, out = ymd_hms(value)) |> pull(out),
+    mutate(test_df, out = ymd_hms(value)) |> pull(out)
+  )
+  expect_equal_lazy(
+    mutate(test_pl, out = ymd_hms(value, tz = "America/New_York")) |> pull(out),
+    mutate(test_df, out = ymd_hms(value, tz = "America/New_York")) |> pull(out)
   )
 })
 

--- a/tests/testthat/test-funs_date-lazy.R
+++ b/tests/testthat/test-funs_date-lazy.R
@@ -168,12 +168,7 @@ test_that("strptime() works", {
   expect_equal_lazy(
     test_pl |> mutate(foo = strptime(somedate, "%b %d %Y")),
     test_df |>
-      mutate(
-        foo = as.POSIXct(
-          strptime(somedate, "%b %d %Y"),
-          tz = Sys.timezone()
-        )
-      )
+      mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y")))
   )
 
   # Polars converts to POSIXct and not to POSIXlt
@@ -221,9 +216,42 @@ test_that("strptime() works", {
   )
 })
 
+test_that("strptime() respects TZ environment variable when tz is empty", {
+  test_df <- tibble(
+    somedate = c("Jul 24 2014", "Jan 21 2016", NA)
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  for (tz in c("UTC", "Europe/London")) {
+    withr::local_envvar(c(TZ = tz))
+
+    expect_equal_lazy(
+      test_pl |> mutate(foo = strptime(somedate, "%b %d %Y")),
+      test_df |> mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y"))),
+      info = tz
+    )
+
+    expect_equal_lazy(
+      attr(
+        test_pl |>
+          mutate(foo = strptime(somedate, "%b %d %Y")) |>
+          pull(foo),
+        "tzone"
+      ),
+      attr(
+        test_df |>
+          mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y"))) |>
+          pull(foo),
+        "tzone"
+      ),
+      info = tz
+    )
+  }
+})
+
 test_that("date parsers respect timezone arguments", {
   test_df <- tibble(
-    value = c("2020-01-02", NA)
+    value = c("2020-01-02", "2026-12-31")
   )
   test_pl <- as_polars_lf(test_df)
 
@@ -237,9 +265,9 @@ test_that("date parsers respect timezone arguments", {
   )
 })
 
-test_that("ymd_hms() respects timezone arguments", {
+test_that("datetime parsers respect timezone arguments", {
   test_df <- tibble(
-    value = c("2020-01-02 12:34:56", NA)
+    value = c("2020-01-02 12:34:56", "2026-12-31 23:59:59")
   )
   test_pl <- as_polars_lf(test_df)
 

--- a/tests/testthat/test-funs_date-lazy.R
+++ b/tests/testthat/test-funs_date-lazy.R
@@ -516,6 +516,19 @@ test_that("make_datetime() works", {
     test_pl |> mutate(foo = make_datetime(year = y, 1, 1, hour = 25)),
     "Invalid time components"
   )
+
+  expect_snapshot_lazy(
+    test_pl |>
+      mutate(
+        foo = make_datetime(
+          year = 2020,
+          month = 1,
+          day = 2,
+          tz = "Not/A_Zone"
+        )
+      ),
+    error = TRUE
+  )
 })
 
 test_that("ISOdatetime() works", {
@@ -611,6 +624,19 @@ test_that("ISOdatetime() works", {
   expect_error_lazy(
     test_pl |> mutate(foo = ISOdatetime(year = y, 1, 1, hour = 25)),
     "Invalid time components"
+  )
+
+  expect_snapshot_lazy(
+    test_pl |>
+      mutate(
+        foo = ISOdatetime(
+          year = 2020,
+          month = 1,
+          day = 2,
+          tz = "Not/A_Zone"
+        )
+      ),
+    error = TRUE
   )
 })
 
@@ -855,6 +881,16 @@ test_that("today() works", {
   expect_equal_lazy(
     filter(test_pl, date >= lubridate::today()),
     filter(test_df, date >= lubridate::today())
+  )
+})
+
+test_that("now() errors on invalid timezones", {
+  test_df <- tibble(x = 1)
+  test_pl <- as_polars_lf(test_df)
+
+  expect_snapshot_lazy(
+    suppressWarnings(mutate(test_pl, foo = now(tzone = "Not/A_Zone"))),
+    error = TRUE
   )
 })
 

--- a/tests/testthat/test-funs_date-lazy.R
+++ b/tests/testthat/test-funs_date-lazy.R
@@ -214,6 +214,15 @@ test_that("strptime() works", {
         foo = as.POSIXct(strptime(TRUE, "%Y-%m-%d %H:%M:%S", tz = "UTC"))
       )
   )
+
+  expect_snapshot_lazy(
+    mutate(test_pl, foo = strptime(somedate, "%b %d %Y", tz = NULL)),
+    error = TRUE
+  )
+  expect_snapshot_lazy(
+    mutate(test_pl, foo = strptime(somedate, "%b %d %Y", tz = "Not/A_Zone")),
+    error = TRUE
+  )
 })
 
 test_that("strptime() respects TZ environment variable when tz is empty", {
@@ -230,22 +239,6 @@ test_that("strptime() respects TZ environment variable when tz is empty", {
       test_df |> mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y"))),
       info = tz
     )
-
-    expect_equal_lazy(
-      attr(
-        test_pl |>
-          mutate(foo = strptime(somedate, "%b %d %Y")) |>
-          pull(foo),
-        "tzone"
-      ),
-      attr(
-        test_df |>
-          mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y"))) |>
-          pull(foo),
-        "tzone"
-      ),
-      info = tz
-    )
   }
 })
 
@@ -256,12 +249,16 @@ test_that("date parsers respect timezone arguments", {
   test_pl <- as_polars_lf(test_df)
 
   expect_equal_lazy(
-    mutate(test_pl, out = ymd(value, tz = "UTC")) |> pull(out),
-    mutate(test_df, out = ymd(value, tz = "UTC")) |> pull(out)
+    mutate(test_pl, out = ymd(value, tz = "UTC")),
+    mutate(test_df, out = ymd(value, tz = "UTC"))
   )
   expect_equal_lazy(
-    mutate(test_pl, out = ymd(value, tz = "America/New_York")) |> pull(out),
-    mutate(test_df, out = ymd(value, tz = "America/New_York")) |> pull(out)
+    mutate(test_pl, out = ymd(value, tz = "America/New_York")),
+    mutate(test_df, out = ymd(value, tz = "America/New_York"))
+  )
+  expect_equal_or_both_error(
+    mutate(test_pl, out = ymd(value, tz = "Not/A_Zone")),
+    mutate(test_df, out = ymd(value, tz = "Not/A_Zone"))
   )
 })
 
@@ -272,12 +269,16 @@ test_that("datetime parsers respect timezone arguments", {
   test_pl <- as_polars_lf(test_df)
 
   expect_equal_lazy(
-    mutate(test_pl, out = ymd_hms(value)) |> pull(out),
-    mutate(test_df, out = ymd_hms(value)) |> pull(out)
+    mutate(test_pl, out = ymd_hms(value)),
+    mutate(test_df, out = ymd_hms(value))
   )
   expect_equal_lazy(
-    mutate(test_pl, out = ymd_hms(value, tz = "America/New_York")) |> pull(out),
-    mutate(test_df, out = ymd_hms(value, tz = "America/New_York")) |> pull(out)
+    mutate(test_pl, out = ymd_hms(value, tz = "America/New_York")),
+    mutate(test_df, out = ymd_hms(value, tz = "America/New_York"))
+  )
+  expect_equal_or_both_error(
+    mutate(test_pl, out = ymd_hms(value, tz = "Not/A_Zone")),
+    mutate(test_df, out = ymd_hms(value, tz = "Not/A_Zone"))
   )
 })
 

--- a/tests/testthat/test-funs_date.R
+++ b/tests/testthat/test-funs_date.R
@@ -164,7 +164,12 @@ test_that("strptime() works", {
   expect_equal(
     test_pl |> mutate(foo = strptime(somedate, "%b %d %Y")),
     test_df |>
-      mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y")))
+      mutate(
+        foo = as.POSIXct(
+          strptime(somedate, "%b %d %Y"),
+          tz = Sys.timezone()
+        )
+      )
   )
 
   # Polars converts to POSIXct and not to POSIXlt
@@ -209,6 +214,38 @@ test_that("strptime() works", {
       mutate(
         foo = as.POSIXct(strptime(TRUE, "%Y-%m-%d %H:%M:%S", tz = "UTC"))
       )
+  )
+})
+
+test_that("date parsers respect timezone arguments", {
+  test_df <- tibble(
+    value = c("2020-01-02", "2026-12-31")
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    mutate(test_pl, out = ymd(value, tz = "UTC")) |> pull(out),
+    mutate(test_df, out = ymd(value, tz = "UTC")) |> pull(out)
+  )
+  expect_equal(
+    mutate(test_pl, out = ymd(value, tz = "America/New_York")) |> pull(out),
+    mutate(test_df, out = ymd(value, tz = "America/New_York")) |> pull(out)
+  )
+})
+
+test_that("datetime parsers respect timezone arguments", {
+  test_df <- tibble(
+    value = c("2020-01-02 12:34:56", "2026-12-31 23:59:59")
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    mutate(test_pl, out = ymd_hms(value)) |> pull(out),
+    mutate(test_df, out = ymd_hms(value)) |> pull(out)
+  )
+  expect_equal(
+    mutate(test_pl, out = ymd_hms(value, tz = "America/New_York")) |> pull(out),
+    mutate(test_df, out = ymd_hms(value, tz = "America/New_York")) |> pull(out)
   )
 })
 

--- a/tests/testthat/test-funs_date.R
+++ b/tests/testthat/test-funs_date.R
@@ -512,6 +512,19 @@ test_that("make_datetime() works", {
     test_pl |> mutate(foo = make_datetime(year = y, 1, 1, hour = 25)),
     "Invalid time components"
   )
+
+  expect_snapshot(
+    test_pl |>
+      mutate(
+        foo = make_datetime(
+          year = 2020,
+          month = 1,
+          day = 2,
+          tz = "Not/A_Zone"
+        )
+      ),
+    error = TRUE
+  )
 })
 
 test_that("ISOdatetime() works", {
@@ -607,6 +620,19 @@ test_that("ISOdatetime() works", {
   expect_error(
     test_pl |> mutate(foo = ISOdatetime(year = y, 1, 1, hour = 25)),
     "Invalid time components"
+  )
+
+  expect_snapshot(
+    test_pl |>
+      mutate(
+        foo = ISOdatetime(
+          year = 2020,
+          month = 1,
+          day = 2,
+          tz = "Not/A_Zone"
+        )
+      ),
+    error = TRUE
   )
 })
 
@@ -851,6 +877,16 @@ test_that("today() works", {
   expect_equal(
     filter(test_pl, date >= lubridate::today()),
     filter(test_df, date >= lubridate::today())
+  )
+})
+
+test_that("now() errors on invalid timezones", {
+  test_df <- tibble(x = 1)
+  test_pl <- as_polars_df(test_df)
+
+  expect_snapshot(
+    suppressWarnings(mutate(test_pl, foo = now(tzone = "Not/A_Zone"))),
+    error = TRUE
   )
 })
 

--- a/tests/testthat/test-funs_date.R
+++ b/tests/testthat/test-funs_date.R
@@ -210,6 +210,15 @@ test_that("strptime() works", {
         foo = as.POSIXct(strptime(TRUE, "%Y-%m-%d %H:%M:%S", tz = "UTC"))
       )
   )
+
+  expect_snapshot(
+    mutate(test_pl, foo = strptime(somedate, "%b %d %Y", tz = NULL)),
+    error = TRUE
+  )
+  expect_snapshot(
+    mutate(test_pl, foo = strptime(somedate, "%b %d %Y", tz = "Not/A_Zone")),
+    error = TRUE
+  )
 })
 
 test_that("strptime() respects TZ environment variable when tz is empty", {
@@ -226,22 +235,6 @@ test_that("strptime() respects TZ environment variable when tz is empty", {
       test_df |> mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y"))),
       info = tz
     )
-
-    expect_equal(
-      attr(
-        test_pl |>
-          mutate(foo = strptime(somedate, "%b %d %Y")) |>
-          pull(foo),
-        "tzone"
-      ),
-      attr(
-        test_df |>
-          mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y"))) |>
-          pull(foo),
-        "tzone"
-      ),
-      info = tz
-    )
   }
 })
 
@@ -252,12 +245,16 @@ test_that("date parsers respect timezone arguments", {
   test_pl <- as_polars_df(test_df)
 
   expect_equal(
-    mutate(test_pl, out = ymd(value, tz = "UTC")) |> pull(out),
-    mutate(test_df, out = ymd(value, tz = "UTC")) |> pull(out)
+    mutate(test_pl, out = ymd(value, tz = "UTC")),
+    mutate(test_df, out = ymd(value, tz = "UTC"))
   )
   expect_equal(
-    mutate(test_pl, out = ymd(value, tz = "America/New_York")) |> pull(out),
-    mutate(test_df, out = ymd(value, tz = "America/New_York")) |> pull(out)
+    mutate(test_pl, out = ymd(value, tz = "America/New_York")),
+    mutate(test_df, out = ymd(value, tz = "America/New_York"))
+  )
+  expect_equal_or_both_error(
+    mutate(test_pl, out = ymd(value, tz = "Not/A_Zone")),
+    mutate(test_df, out = ymd(value, tz = "Not/A_Zone"))
   )
 })
 
@@ -268,12 +265,16 @@ test_that("datetime parsers respect timezone arguments", {
   test_pl <- as_polars_df(test_df)
 
   expect_equal(
-    mutate(test_pl, out = ymd_hms(value)) |> pull(out),
-    mutate(test_df, out = ymd_hms(value)) |> pull(out)
+    mutate(test_pl, out = ymd_hms(value)),
+    mutate(test_df, out = ymd_hms(value))
   )
   expect_equal(
-    mutate(test_pl, out = ymd_hms(value, tz = "America/New_York")) |> pull(out),
-    mutate(test_df, out = ymd_hms(value, tz = "America/New_York")) |> pull(out)
+    mutate(test_pl, out = ymd_hms(value, tz = "America/New_York")),
+    mutate(test_df, out = ymd_hms(value, tz = "America/New_York"))
+  )
+  expect_equal_or_both_error(
+    mutate(test_pl, out = ymd_hms(value, tz = "Not/A_Zone")),
+    mutate(test_df, out = ymd_hms(value, tz = "Not/A_Zone"))
   )
 })
 

--- a/tests/testthat/test-funs_date.R
+++ b/tests/testthat/test-funs_date.R
@@ -164,12 +164,7 @@ test_that("strptime() works", {
   expect_equal(
     test_pl |> mutate(foo = strptime(somedate, "%b %d %Y")),
     test_df |>
-      mutate(
-        foo = as.POSIXct(
-          strptime(somedate, "%b %d %Y"),
-          tz = Sys.timezone()
-        )
-      )
+      mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y")))
   )
 
   # Polars converts to POSIXct and not to POSIXlt
@@ -215,6 +210,39 @@ test_that("strptime() works", {
         foo = as.POSIXct(strptime(TRUE, "%Y-%m-%d %H:%M:%S", tz = "UTC"))
       )
   )
+})
+
+test_that("strptime() respects TZ environment variable when tz is empty", {
+  test_df <- tibble(
+    somedate = c("Jul 24 2014", "Jan 21 2016", NA)
+  )
+  test_pl <- as_polars_df(test_df)
+
+  for (tz in c("UTC", "Europe/London")) {
+    withr::local_envvar(c(TZ = tz))
+
+    expect_equal(
+      test_pl |> mutate(foo = strptime(somedate, "%b %d %Y")),
+      test_df |> mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y"))),
+      info = tz
+    )
+
+    expect_equal(
+      attr(
+        test_pl |>
+          mutate(foo = strptime(somedate, "%b %d %Y")) |>
+          pull(foo),
+        "tzone"
+      ),
+      attr(
+        test_df |>
+          mutate(foo = as.POSIXct(strptime(somedate, "%b %d %Y"))) |>
+          pull(foo),
+        "tzone"
+      ),
+      info = tz
+    )
+  }
 })
 
 test_that("date parsers respect timezone arguments", {


### PR DESCRIPTION
Close #361 

- Added `tz` parameter to `ymd()` family of functions and `ymd_hms()` function
- Fixed an issue where `tidypolars::pl_strptime()` behaved inconsistently with `base::strptime()` when defaulting to `tz = ""`