### PR TITLE
fix: Fix ANSI codes in column names after `count()` / `add_count()` with `{{ }}`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 * Fix `relocate()` to handle `<tidy-select>` helpers consistently with `dplyr`
   (@Yousa-Mirage, #357).
 * Using the `tz` argument in `strptime()` no longer errors (@dejse, #361)
+* Fix regression in column names after `count()` or `add_count()` with `{{ }}`
+  (#366).
 
 ## Bug fixes
 

--- a/R/count.R
+++ b/R/count.R
@@ -88,9 +88,10 @@ count.polars_data_frame <- function(
   }
 
   if (is.null(names(polars_exprs))) {
-    new_names <- enexprs(...)
-    new_names <- lapply(new_names, expr_deparse)
-    names(polars_exprs) <- unlist(new_names, use.names = FALSE)
+    new_names <- enexprs(...) |>
+      exprs_auto_name() |>
+      names()
+    names(polars_exprs) <- new_names
   }
 
   if (is_grouped) {
@@ -225,9 +226,10 @@ add_count.polars_data_frame <- function(
   }
 
   if (is.null(names(polars_exprs))) {
-    new_names <- enexprs(...)
-    new_names <- lapply(new_names, expr_deparse)
-    names(polars_exprs) <- unlist(new_names, use.names = FALSE)
+    new_names <- enexprs(...) |>
+      exprs_auto_name() |>
+      names()
+    names(polars_exprs) <- new_names
   }
 
   name <- check_count_name(x, names(x), name)

--- a/tests/testthat/test-count-lazy.R
+++ b/tests/testthat/test-count-lazy.R
@@ -261,20 +261,20 @@ test_that("no ANSI code in column names when using `{{ }}`, #365", {
   test_df <- as_tibble(mtcars)
   test_pl <- as_polars_lf(test_df)
 
-  count_and_filter <- function(data, col1, col2) {
+  my_count <- function(data, col1, col2) {
     data |> count({{ col1 }}, {{ col2 }})
   }
-  add_count_and_filter <- function(data, col1, col2) {
+  my_add_count <- function(data, col1, col2) {
     data |> add_count({{ col1 }}, {{ col2 }})
   }
 
   expect_equal_lazy(
-    test_pl |> count_and_filter(drat, cyl),
-    test_df |> count_and_filter(drat, cyl)
+    test_pl |> my_count(drat, cyl),
+    test_df |> my_count(drat, cyl)
   )
   expect_equal_lazy(
-    test_pl |> add_count_and_filter(drat, cyl),
-    test_df |> add_count_and_filter(drat, cyl)
+    test_pl |> my_add_count(drat, cyl),
+    test_df |> my_add_count(drat, cyl)
   )
 })
 

--- a/tests/testthat/test-count-lazy.R
+++ b/tests/testthat/test-count-lazy.R
@@ -257,4 +257,25 @@ test_that("count() and add_count() explicitly do not support 'wt'", {
   )
 })
 
+test_that("no ANSI code in column names when using `{{ }}`, #365", {
+  test_df <- as_tibble(mtcars)
+  test_pl <- as_polars_lf(test_df)
+
+  count_and_filter <- function(data, col1, col2) {
+    data |> count({{ col1 }}, {{ col2 }})
+  }
+  add_count_and_filter <- function(data, col1, col2) {
+    data |> add_count({{ col1 }}, {{ col2 }})
+  }
+
+  expect_equal_lazy(
+    test_pl |> count_and_filter(drat, cyl),
+    test_df |> count_and_filter(drat, cyl)
+  )
+  expect_equal_lazy(
+    test_pl |> add_count_and_filter(drat, cyl),
+    test_df |> add_count_and_filter(drat, cyl)
+  )
+})
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -252,3 +252,24 @@ test_that("count() and add_count() explicitly do not support 'wt'", {
     }
   )
 })
+
+test_that("no ANSI code in column names when using `{{ }}`, #365", {
+  test_df <- as_tibble(mtcars)
+  test_pl <- as_polars_df(test_df)
+
+  count_and_filter <- function(data, col1, col2) {
+    data |> count({{ col1 }}, {{ col2 }})
+  }
+  add_count_and_filter <- function(data, col1, col2) {
+    data |> add_count({{ col1 }}, {{ col2 }})
+  }
+
+  expect_equal(
+    test_pl |> count_and_filter(drat, cyl),
+    test_df |> count_and_filter(drat, cyl)
+  )
+  expect_equal(
+    test_pl |> add_count_and_filter(drat, cyl),
+    test_df |> add_count_and_filter(drat, cyl)
+  )
+})

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -257,19 +257,19 @@ test_that("no ANSI code in column names when using `{{ }}`, #365", {
   test_df <- as_tibble(mtcars)
   test_pl <- as_polars_df(test_df)
 
-  count_and_filter <- function(data, col1, col2) {
+  my_count <- function(data, col1, col2) {
     data |> count({{ col1 }}, {{ col2 }})
   }
-  add_count_and_filter <- function(data, col1, col2) {
+  my_add_count <- function(data, col1, col2) {
     data |> add_count({{ col1 }}, {{ col2 }})
   }
 
   expect_equal(
-    test_pl |> count_and_filter(drat, cyl),
-    test_df |> count_and_filter(drat, cyl)
+    test_pl |> my_count(drat, cyl),
+    test_df |> my_count(drat, cyl)
   )
   expect_equal(
-    test_pl |> add_count_and_filter(drat, cyl),
-    test_df |> add_count_and_filter(drat, cyl)
+    test_pl |> my_add_count(drat, cyl),
+    test_df |> my_add_count(drat, cyl)
   )
 })


### PR DESCRIPTION
Fixes #365 