### PR TITLE
fix: Errors and inconsistency when using `-` in `arrange()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,10 +9,11 @@
 
 ## Bug fixes
 
-* `arrange()` no longer modifies its input, which could cause unary `-`
-  expressions in later operations to produce incorrect results. And `arrange()`
-  now errors consistently with `dplyr` when unary `-` is applied to unsupported
-  types such as character columns (#374, @Yousa-Mirage).
+- `arrange()` no longer modifies its input, which could cause unary `-` expressions in later operations
+  to produce incorrect results (#374, @Yousa-Mirage).
+
+- `arrange()` now errors consistently with `dplyr` when unary `-` is applied to unsupported types such as
+  character columns (#374, @Yousa-Mirage).
 
 
 # tidypolars 0.19.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,10 +10,9 @@
 ## Bug fixes
 
 * `arrange()` no longer modifies its input, which could cause unary `-`
-  expressions in later operations to produce incorrect results.
-
-* `arrange()` now errors consistently with `dplyr` when unary `-` is applied
-  to unsupported types such as character columns.
+  expressions in later operations to produce incorrect results. And `arrange()`
+  now errors consistently with `dplyr` when unary `-` is applied to unsupported
+  types such as character columns (#374, @Yousa-Mirage).
 
 
 # tidypolars 0.19.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,14 @@
 * Added support for `show_query()` to print the pure `polars` code that is equivalent to the
   query (#369).
 
+## Bug fixes
+
+* `arrange()` no longer modifies its input, which could cause unary `-`
+  expressions in later operations to produce incorrect results.
+
+* `arrange()` now errors consistently with `dplyr` when unary `-` is applied
+  to unsupported types such as character columns.
+
 
 # tidypolars 0.19.0
 

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -28,13 +28,12 @@ arrange.polars_data_frame <- function(.data, ..., .by_group = FALSE) {
   mo <- attributes(.data)$maintain_grp_order
   is_grouped <- !is.null(grps)
 
-  attr(.data, "called_from_arrange") <- TRUE
-
   polars_exprs <- translate_dots(
     .data,
     ...,
     env = rlang::current_env(),
-    caller = rlang::caller_env()
+    caller = rlang::caller_env(),
+    called_from_arrange = TRUE
   )
 
   descending <- vapply(

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -28,12 +28,19 @@ arrange.polars_data_frame <- function(.data, ..., .by_group = FALSE) {
   mo <- attributes(.data)$maintain_grp_order
   is_grouped <- !is.null(grps)
 
+  attr(.data, "called_from_arrange") <- TRUE
+  on.exit(
+    {
+      attr(.data, "called_from_arrange") <- NULL
+    },
+    add = TRUE
+  )
+
   polars_exprs <- translate_dots(
     .data,
     ...,
     env = rlang::current_env(),
-    caller = rlang::caller_env(),
-    called_from_arrange = TRUE
+    caller = rlang::caller_env()
   )
 
   descending <- vapply(

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -29,12 +29,9 @@ arrange.polars_data_frame <- function(.data, ..., .by_group = FALSE) {
   is_grouped <- !is.null(grps)
 
   attr(.data, "called_from_arrange") <- TRUE
-  on.exit(
-    {
-      attr(.data, "called_from_arrange") <- NULL
-    },
-    add = TRUE
-  )
+  on.exit({
+    attr(.data, "called_from_arrange") <- NULL
+  })
 
   polars_exprs <- translate_dots(
     .data,

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -19,6 +19,8 @@
 #' @param env Environment of the function from which this expression is called
 #' (`filter()`, `mutate()` or `summarize()`).
 #' @param caller User environment in which the function is called.
+#' @param called_from_arrange Whether unary `-` expressions should be rewritten
+#'   for use as sort expressions.
 #'
 #' @noRd
 #'
@@ -26,23 +28,28 @@
 #' created variables, then the list will contains sublists, one per `$with_columns()`
 #' call to make.
 
-translate_dots <- function(.data, ..., env, caller) {
+translate_dots <- function(
+  .data,
+  ...,
+  env,
+  caller,
+  called_from_arrange = FALSE
+) {
   dots <- enquos(...)
   if (length(dots) == 0) {
     return()
   }
   dots <- lapply(dots, quo_squash)
   new_vars <- c()
-  called_from_arrange <- attr(.data, "called_from_arrange") %||% FALSE
 
   out <- lapply(seq_along(dots), \(x) {
     expr <- dots[[x]]
 
-    # arrange() is a special case since using "-" on a character column is
-    # accepted but invalid for Polars so we need to replace "-" by "desc()"
-    # before translating.
+    # Polars doesn't support unary `-` on logical columns, while R coerces them
+    # to integers. Multiplication preserves R's accepted types and still errors
+    # for unsupported types such as character and date columns.
     if (isTRUE(called_from_arrange) && length(expr) == 2 && expr[[1]] == "-") {
-      expr <- call2("desc", expr[[2]])
+      expr <- call2("*", expr[[2]], -1)
     }
 
     tmp <- translate_expr(

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -45,9 +45,8 @@ translate_dots <- function(
   out <- lapply(seq_along(dots), \(x) {
     expr <- dots[[x]]
 
-    # Polars doesn't support unary `-` on logical columns, while R coerces them
-    # to integers. Multiplication preserves R's accepted types and still errors
-    # for unsupported types such as character and date columns.
+    # Using a multiplication here ensures that we support `-x` when `x` is a bool 
+    # column and that we error on `-x` when `x` is a character column, like `dplyr`. 
     if (isTRUE(called_from_arrange) && length(expr) == 2 && expr[[1]] == "-") {
       expr <- call2("*", expr[[2]], -1)
     }

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -19,8 +19,6 @@
 #' @param env Environment of the function from which this expression is called
 #' (`filter()`, `mutate()` or `summarize()`).
 #' @param caller User environment in which the function is called.
-#' @param called_from_arrange Whether unary `-` expressions should be rewritten
-#'   for use as sort expressions.
 #'
 #' @noRd
 #'
@@ -28,25 +26,20 @@
 #' created variables, then the list will contains sublists, one per `$with_columns()`
 #' call to make.
 
-translate_dots <- function(
-  .data,
-  ...,
-  env,
-  caller,
-  called_from_arrange = FALSE
-) {
+translate_dots <- function(.data, ..., env, caller) {
   dots <- enquos(...)
   if (length(dots) == 0) {
     return()
   }
   dots <- lapply(dots, quo_squash)
   new_vars <- c()
+  called_from_arrange <- attr(.data, "called_from_arrange") %||% FALSE
 
   out <- lapply(seq_along(dots), \(x) {
     expr <- dots[[x]]
 
-    # Using a multiplication here ensures that we support `-x` when `x` is a bool 
-    # column and that we error on `-x` when `x` is a character column, like `dplyr`. 
+    # Using a multiplication here ensures that we support `-x` when `x` is a bool
+    # column and that we error on `-x` when `x` is a character column, like `dplyr`.
     if (isTRUE(called_from_arrange) && length(expr) == 2 && expr[[1]] == "-") {
       expr <- call2("*", expr[[2]], -1)
     }

--- a/tests/testthat/test-arrange-lazy.R
+++ b/tests/testthat/test-arrange-lazy.R
@@ -34,12 +34,12 @@ test_that("basic behavior works", {
 patrick::with_parameters_test_that(
   "using desc() works with different column types",
   {
-    test <- tibble(x = x)
-    test_pl <- as_polars_lf(test)
+    test_df <- tibble(x = x)
+    test_pl <- as_polars_lf(test_df)
 
     expect_equal_lazy(
       arrange(test_pl, desc(x)),
-      arrange(test, desc(x))
+      arrange(test_df, desc(x))
     )
   },
   x = list(
@@ -148,7 +148,7 @@ test_that("works with expressions", {
   )
 })
 
-test_that("does not modify its input", {
+test_that("does not modify its input, #374", {
   test <- tibble(mpg = c(1, 2, 3))
   test_pl <- as_polars_lf(test)
 
@@ -162,12 +162,12 @@ test_that("does not modify its input", {
 })
 
 patrick::with_parameters_test_that(
-  "unary minus works with supported column types",
+  "unary minus matches dplyr with different column types",
   {
     test <- tibble(x = x)
     test_pl <- as_polars_lf(test)
 
-    expect_equal_lazy(
+    expect_equal_or_both_error(
       arrange(test_pl, -x),
       arrange(test, -x)
     )
@@ -176,22 +176,7 @@ patrick::with_parameters_test_that(
     c(2, 1, 3),
     c(2L, 1L, 3L),
     c(TRUE, FALSE, TRUE),
-    as.difftime(c(7200, 3600, 10800), units = "secs")
-  )
-)
-
-patrick::with_parameters_test_that(
-  "unary minus errors for unsupported column types",
-  {
-    test <- tibble(x = x)
-    test_pl <- as_polars_lf(test)
-
-    expect_both_error(
-      arrange(test_pl, -x),
-      arrange(test, -x)
-    )
-  },
-  x = list(
+    as.difftime(c(7200, 3600, 10800), units = "secs"),
     c("b", "a", "c"),
     as.Date(c("2020-01-02", "2020-01-01", "2020-01-03")),
     as.POSIXct(

--- a/tests/testthat/test-arrange-lazy.R
+++ b/tests/testthat/test-arrange-lazy.R
@@ -137,6 +137,50 @@ test_that("works with expressions", {
   )
 })
 
+test_that("does not modify its input", {
+  test <- tibble(mpg = c(1, 2, 3))
+  test_pl <- as_polars_lf(test)
+
+  invisible(arrange(test, mpg))
+  invisible(arrange(test_pl, mpg))
+
+  expect_equal_lazy(
+    test_pl |> mutate(z = -mpg),
+    test |> mutate(z = -mpg)
+  )
+})
+
+test_that("unary minus works with logical columns", {
+  test <- tibble(x = c(TRUE, FALSE, TRUE))
+  test_pl <- as_polars_lf(test)
+
+  expect_equal_lazy(
+    arrange(test_pl, -x),
+    arrange(test, -x)
+  )
+})
+
+patrick::with_parameters_test_that(
+  "unary minus errors for unsupported column types",
+  {
+    test <- tibble(x = x)
+    test_pl <- as_polars_lf(test)
+
+    expect_both_error(
+      arrange(test_pl, -x),
+      arrange(test, -x)
+    )
+  },
+  x = list(
+    c("b", "a", "c"),
+    as.Date(c("2020-01-02", "2020-01-01", "2020-01-03")),
+    as.POSIXct(
+      c("2020-01-02", "2020-01-01", "2020-01-03"),
+      tz = "UTC"
+    )
+  )
+)
+
 test_that("NA are placed last", {
   test_df <- tibble(
     x = c(2, 1, 3, NA),

--- a/tests/testthat/test-arrange-lazy.R
+++ b/tests/testthat/test-arrange-lazy.R
@@ -31,23 +31,29 @@ test_that("basic behavior works", {
   )
 })
 
-test_that("using desc() works", {
-  test_df <- tibble(
-    x1 = c("a", "a", "b", "a", "c"),
-    x2 = c(2, 1, 5, 3, 1),
-    value = sample.int(5, )
-  )
-  test_pl <- as_polars_lf(test_df)
-  expect_equal_lazy(
-    arrange(test_pl, desc(x2)),
-    arrange(test_df, -x2)
-  )
+patrick::with_parameters_test_that(
+  "using desc() works with different column types",
+  {
+    test <- tibble(x = x)
+    test_pl <- as_polars_lf(test)
 
-  expect_equal_lazy(
-    arrange(test_pl, desc(x2), desc(value)),
-    arrange(test_df, -x2, -value)
+    expect_equal_lazy(
+      arrange(test_pl, desc(x)),
+      arrange(test, desc(x))
+    )
+  },
+  x = list(
+    c(2, 1, 3),
+    c(2L, 1L, 3L),
+    c(TRUE, FALSE, TRUE),
+    c("b", "a", "c"),
+    as.Date(c("2020-01-02", "2020-01-01", "2020-01-03")),
+    as.POSIXct(
+      c("2020-01-02", "2020-01-01", "2020-01-03"),
+      tz = "UTC"
+    )
   )
-})
+)
 
 test_that("sorting by multiple variables works", {
   test_df <- tibble(
@@ -59,6 +65,11 @@ test_that("sorting by multiple variables works", {
   expect_equal_lazy(
     arrange(test_pl, x1, -x2),
     arrange(test_df, x1, -x2)
+  )
+
+  expect_equal_lazy(
+    arrange(test_pl, desc(x1), desc(x2)),
+    arrange(test_df, desc(x1), desc(x2))
   )
 })
 
@@ -150,15 +161,24 @@ test_that("does not modify its input", {
   )
 })
 
-test_that("unary minus works with logical columns", {
-  test <- tibble(x = c(TRUE, FALSE, TRUE))
-  test_pl <- as_polars_lf(test)
+patrick::with_parameters_test_that(
+  "unary minus works with supported column types",
+  {
+    test <- tibble(x = x)
+    test_pl <- as_polars_lf(test)
 
-  expect_equal_lazy(
-    arrange(test_pl, -x),
-    arrange(test, -x)
+    expect_equal_lazy(
+      arrange(test_pl, -x),
+      arrange(test, -x)
+    )
+  },
+  x = list(
+    c(2, 1, 3),
+    c(2L, 1L, 3L),
+    c(TRUE, FALSE, TRUE),
+    as.difftime(c(7200, 3600, 10800), units = "secs")
   )
-})
+)
 
 patrick::with_parameters_test_that(
   "unary minus errors for unsupported column types",

--- a/tests/testthat/test-arrange.R
+++ b/tests/testthat/test-arrange.R
@@ -144,7 +144,7 @@ test_that("works with expressions", {
   )
 })
 
-test_that("does not modify its input", {
+test_that("does not modify its input, #374", {
   test <- tibble(mpg = c(1, 2, 3))
   test_pl <- as_polars_df(test)
 

--- a/tests/testthat/test-arrange.R
+++ b/tests/testthat/test-arrange.R
@@ -133,6 +133,50 @@ test_that("works with expressions", {
   )
 })
 
+test_that("does not modify its input", {
+  test <- tibble(mpg = c(1, 2, 3))
+  test_pl <- as_polars_df(test)
+
+  invisible(arrange(test, mpg))
+  invisible(arrange(test_pl, mpg))
+
+  expect_equal(
+    test_pl |> mutate(z = -mpg),
+    test |> mutate(z = -mpg)
+  )
+})
+
+test_that("unary minus works with logical columns", {
+  test <- tibble(x = c(TRUE, FALSE, TRUE))
+  test_pl <- as_polars_df(test)
+
+  expect_equal(
+    arrange(test_pl, -x),
+    arrange(test, -x)
+  )
+})
+
+patrick::with_parameters_test_that(
+  "unary minus errors for unsupported column types",
+  {
+    test <- tibble(x = x)
+    test_pl <- as_polars_df(test)
+
+    expect_both_error(
+      arrange(test_pl, -x),
+      arrange(test, -x)
+    )
+  },
+  x = list(
+    c("b", "a", "c"),
+    as.Date(c("2020-01-02", "2020-01-01", "2020-01-03")),
+    as.POSIXct(
+      c("2020-01-02", "2020-01-01", "2020-01-03"),
+      tz = "UTC"
+    )
+  )
+)
+
 test_that("NA are placed last", {
   test_df <- tibble(
     x = c(2, 1, 3, NA),

--- a/tests/testthat/test-arrange.R
+++ b/tests/testthat/test-arrange.R
@@ -30,12 +30,12 @@ test_that("basic behavior works", {
 patrick::with_parameters_test_that(
   "using desc() works with different column types",
   {
-    test <- tibble(x = x)
-    test_pl <- as_polars_df(test)
+    test_df <- tibble(x = x)
+    test_pl <- as_polars_df(test_df)
 
     expect_equal(
       arrange(test_pl, desc(x)),
-      arrange(test, desc(x))
+      arrange(test_df, desc(x))
     )
   },
   x = list(

--- a/tests/testthat/test-arrange.R
+++ b/tests/testthat/test-arrange.R
@@ -158,12 +158,12 @@ test_that("does not modify its input, #374", {
 })
 
 patrick::with_parameters_test_that(
-  "unary minus works with supported column types",
+  "unary minus matches dplyr with different column types",
   {
     test <- tibble(x = x)
     test_pl <- as_polars_df(test)
 
-    expect_equal(
+    expect_equal_or_both_error(
       arrange(test_pl, -x),
       arrange(test, -x)
     )
@@ -172,22 +172,7 @@ patrick::with_parameters_test_that(
     c(2, 1, 3),
     c(2L, 1L, 3L),
     c(TRUE, FALSE, TRUE),
-    as.difftime(c(7200, 3600, 10800), units = "secs")
-  )
-)
-
-patrick::with_parameters_test_that(
-  "unary minus errors for unsupported column types",
-  {
-    test <- tibble(x = x)
-    test_pl <- as_polars_df(test)
-
-    expect_both_error(
-      arrange(test_pl, -x),
-      arrange(test, -x)
-    )
-  },
-  x = list(
+    as.difftime(c(7200, 3600, 10800), units = "secs"),
     c("b", "a", "c"),
     as.Date(c("2020-01-02", "2020-01-01", "2020-01-03")),
     as.POSIXct(

--- a/tests/testthat/test-arrange.R
+++ b/tests/testthat/test-arrange.R
@@ -27,23 +27,29 @@ test_that("basic behavior works", {
   )
 })
 
-test_that("using desc() works", {
-  test_df <- tibble(
-    x1 = c("a", "a", "b", "a", "c"),
-    x2 = c(2, 1, 5, 3, 1),
-    value = sample.int(5, )
-  )
-  test_pl <- as_polars_df(test_df)
-  expect_equal(
-    arrange(test_pl, desc(x2)),
-    arrange(test_df, -x2)
-  )
+patrick::with_parameters_test_that(
+  "using desc() works with different column types",
+  {
+    test <- tibble(x = x)
+    test_pl <- as_polars_df(test)
 
-  expect_equal(
-    arrange(test_pl, desc(x2), desc(value)),
-    arrange(test_df, -x2, -value)
+    expect_equal(
+      arrange(test_pl, desc(x)),
+      arrange(test, desc(x))
+    )
+  },
+  x = list(
+    c(2, 1, 3),
+    c(2L, 1L, 3L),
+    c(TRUE, FALSE, TRUE),
+    c("b", "a", "c"),
+    as.Date(c("2020-01-02", "2020-01-01", "2020-01-03")),
+    as.POSIXct(
+      c("2020-01-02", "2020-01-01", "2020-01-03"),
+      tz = "UTC"
+    )
   )
-})
+)
 
 test_that("sorting by multiple variables works", {
   test_df <- tibble(
@@ -55,6 +61,11 @@ test_that("sorting by multiple variables works", {
   expect_equal(
     arrange(test_pl, x1, -x2),
     arrange(test_df, x1, -x2)
+  )
+
+  expect_equal(
+    arrange(test_pl, desc(x1), desc(x2)),
+    arrange(test_df, desc(x1), desc(x2))
   )
 })
 
@@ -146,15 +157,24 @@ test_that("does not modify its input", {
   )
 })
 
-test_that("unary minus works with logical columns", {
-  test <- tibble(x = c(TRUE, FALSE, TRUE))
-  test_pl <- as_polars_df(test)
+patrick::with_parameters_test_that(
+  "unary minus works with supported column types",
+  {
+    test <- tibble(x = x)
+    test_pl <- as_polars_df(test)
 
-  expect_equal(
-    arrange(test_pl, -x),
-    arrange(test, -x)
+    expect_equal(
+      arrange(test_pl, -x),
+      arrange(test, -x)
+    )
+  },
+  x = list(
+    c(2, 1, 3),
+    c(2L, 1L, 3L),
+    c(TRUE, FALSE, TRUE),
+    as.difftime(c(7200, 3600, 10800), units = "secs")
   )
-})
+)
 
 patrick::with_parameters_test_that(
   "unary minus errors for unsupported column types",


### PR DESCRIPTION
This PR fixed two issues with `arrange()`:

- `arrange()` mutated the input Polars object, causing subsequent unary `-` expressions to be incorrectly interpreted as descending sort expressions.
	``` r
	library(dplyr)
	library(tidypolars)
	
	test_pl <- tibble(mpg = c(1, 2, 3)) |> as_polars_df()
	test_pl |> arrange(mpg)  # call `arrange()` directly
	
	attr(test_pl, "called_from_arrange")
	#> [1] TRUE
	
	test_pl |> mutate(z = -mpg) # ERROR RESULT!
	#> shape: (3, 2)
	#> ┌─────┬─────┐
	#> │ mpg ┆ z   │
	#> │ --- ┆ --- │
	#> │ f64 ┆ f64 │
	#> ╞═════╪═════╡
	#> │ 1.0 ┆ 1.0 │
	#> │ 2.0 ┆ 2.0 │
	#> │ 3.0 ┆ 3.0 │
	#> └─────┴─────┘
	```
- `arrange()` incorrectly allowed unary `-` on character columns instead of raising the same error as `dplyr`.
	``` r
	library(dplyr)
	library(tidypolars)
	
	test_df <- tibble(mpg = c("1", "2", "3"))
	test_pl <- as_polars_df(test_df)
	
	arrange(test_df, -mpg)
	#> Error in `arrange()`:
	#> ℹ In argument: `..1 = -mpg`.
	#> Caused by error in `-mpg`:
	#> ! invalid argument to unary operator
	arrange(test_pl, -mpg)
	#> shape: (3, 1)
	#> ┌─────┐
	#> │ mpg │
	#> │ --- │
	#> │ str │
	#> ╞═════╡
	#> │ 3   │
	#> │ 2   │
	#> │ 1   │
	#> └─────┘
	```