### PR TITLE
fix: Ensure that `distinct()` on grouped data also reports groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,11 @@
 * Added support for `show_query()` to print the pure `polars` code that is equivalent to the
   query (#369).
 
+## Bug fixes
+
+* Fix `distinct()` on grouped data to include grouping variables in the distinct keys,
+  retain grouping columns, and preserve grouping metadata.
+
 
 # tidypolars 0.19.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 ## Bug fixes
 
 * Fix `distinct()` on grouped data to include grouping variables in the distinct keys,
-  retain grouping columns, and preserve grouping metadata.
+  retain grouping columns, and preserve grouping metadata (#376, @Yousa-Mirage).
 
 
 # tidypolars 0.19.0

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -36,15 +36,14 @@ distinct.polars_data_frame <- function(
   maintain_order = TRUE
 ) {
   .data <- tag_frame(.data, substitute(.data))
-
-  groups <- attributes(.data)$pl_grps
-  maintain_group_order <- attributes(.data)$maintain_grp_order %||% FALSE
+  grps <- attributes(.data)$pl_grps
+  mo <- attributes(.data)$maintain_grp_order %||% FALSE
 
   vars <- tidyselect_dots(.data, ...)
   if (length(vars) == 0) {
     vars <- names(.data)
   } else {
-    vars <- unique(c(groups, vars))
+    vars <- unique(c(grps, vars))
   }
   if (!.keep_all) {
     .data <- .data$select(!!!vars)
@@ -54,11 +53,11 @@ distinct.polars_data_frame <- function(
     keep = keep,
     maintain_order = maintain_order
   )
-  if (length(groups) > 0) {
+  if (length(grps) > 0) {
     out <- group_by(
       out,
-      all_of(groups),
-      maintain_order = maintain_group_order
+      all_of(grps),
+      maintain_order = mo
     )
   }
   add_tidypolars_class(out)

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -54,11 +54,7 @@ distinct.polars_data_frame <- function(
     maintain_order = maintain_order
   )
   if (length(grps) > 0) {
-    out <- group_by(
-      out,
-      all_of(grps),
-      maintain_order = mo
-    )
+    out <- group_by(out, all_of(grps), maintain_order = mo)
   }
   add_tidypolars_class(out)
 }

--- a/R/distinct.R
+++ b/R/distinct.R
@@ -36,9 +36,15 @@ distinct.polars_data_frame <- function(
   maintain_order = TRUE
 ) {
   .data <- tag_frame(.data, substitute(.data))
+
+  groups <- attributes(.data)$pl_grps
+  maintain_group_order <- attributes(.data)$maintain_grp_order %||% FALSE
+
   vars <- tidyselect_dots(.data, ...)
   if (length(vars) == 0) {
     vars <- names(.data)
+  } else {
+    vars <- unique(c(groups, vars))
   }
   if (!.keep_all) {
     .data <- .data$select(!!!vars)
@@ -48,6 +54,13 @@ distinct.polars_data_frame <- function(
     keep = keep,
     maintain_order = maintain_order
   )
+  if (length(groups) > 0) {
+    out <- group_by(
+      out,
+      all_of(groups),
+      maintain_order = maintain_group_order
+    )
+  }
   add_tidypolars_class(out)
 }
 

--- a/tests/testthat/test-distinct-lazy.R
+++ b/tests/testthat/test-distinct-lazy.R
@@ -97,4 +97,27 @@ test_that("argument .keep_all works", {
   )
 })
 
+test_that("distinct() respects groups", {
+  test_df <- tibble(
+    g = c("a", "a", "b", "b"),
+    x = c(1, 1, 1, 2)
+  ) |>
+    group_by(g)
+  test_pl <- as_polars_lf(test_df) |>
+    group_by(g)
+
+  expect_equal_lazy(
+    distinct(test_pl, x),
+    distinct(test_df, x)
+  )
+  expect_equal_lazy(
+    distinct(test_pl, x, .keep_all = TRUE),
+    distinct(test_df, x, .keep_all = TRUE)
+  )
+  expect_equal_lazy(
+    distinct(test_pl),
+    distinct(test_df)
+  )
+})
+
 Sys.setenv('TIDYPOLARS_TEST' = FALSE)

--- a/tests/testthat/test-distinct.R
+++ b/tests/testthat/test-distinct.R
@@ -92,3 +92,26 @@ test_that("argument .keep_all works", {
     distinct(test_df, iso_o, iso_d, .keep_all = TRUE)
   )
 })
+
+test_that("distinct() respects groups", {
+  test_df <- tibble(
+    g = c("a", "a", "b", "b"),
+    x = c(1, 1, 1, 2)
+  ) |>
+    group_by(g)
+  test_pl <- as_polars_df(test_df) |>
+    group_by(g)
+
+  expect_equal(
+    distinct(test_pl, x),
+    distinct(test_df, x)
+  )
+  expect_equal(
+    distinct(test_pl, x, .keep_all = TRUE),
+    distinct(test_df, x, .keep_all = TRUE)
+  )
+  expect_equal(
+    distinct(test_pl),
+    distinct(test_df)
+  )
+})


### PR DESCRIPTION
Fixed `distinct()` on grouped data to include grouping variables in deduplication keys and preserve grouping columns and metadata.

Previous:

``` r
library(dplyr)
library(tidypolars)

df <- tibble(
  g = c("a", "a", "b", "b"),
  x = c(1, 1, 1, 2),
)
df_pl <- as_polars_df(df)

df |> group_by(g) |> distinct(x)
#> # A tibble: 3 × 2
#> # Groups:   g [2]
#>   g         x
#>   <chr> <dbl>
#> 1 a         1
#> 2 b         1
#> 3 b         2
df_pl |> group_by(g) |> distinct(x)
#> shape: (2, 1)
#> ┌─────┐
#> │ x   │
#> │ --- │
#> │ f64 │
#> ╞═════╡
#> │ 1.0 │
#> │ 2.0 │
#> └─────┘
```
