### PR TITLE
fix: Improve behaviour of `seq()` in several cases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 ## Bug fixes
 
 * Fix `seq()` to correctly handle descending sequences, negative steps,
-  single-value results, and `by = 0` consistently with base R.
+  single-value results, and `by = 0` consistently with base R (#377, @Yousa-Mirage).
 
 
 # tidypolars 0.19.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,11 @@
 * Added support for `show_query()` to print the pure `polars` code that is equivalent to the
   query (#369).
 
+## Bug fixes
+
+* Fix `seq()` to correctly handle descending sequences, negative steps,
+  single-value results, and `by = 0` consistently with base R.
+
 
 # tidypolars 0.19.0
 

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -413,7 +413,13 @@ pl_seq <- function(from = 1, to = 1, by = NULL, ...) {
   to <- polars_expr_to_r(to)
   from <- polars_expr_to_r(from)
 
-  by <- by %||% (if (to >= from) 1 else -1)
+  if (is.null(by)) {
+    by <- if (to >= from) {
+      1
+    } else {
+      -1
+    }
+  }
 
   if (by == 0) {
     if (to == from) {

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -412,9 +412,21 @@ pl_seq <- function(from = 1, to = 1, by = NULL, ...) {
   by <- polars_expr_to_r(by)
   to <- polars_expr_to_r(to)
   from <- polars_expr_to_r(from)
-  by <- by %||% 1
-  out <- pl$int_range(start = from, end = to + 1, step = by)
-  if ((to - from) == 1) {
+
+  by <- by %||% (if (to >= from) 1 else -1)
+
+  if (by == 0) {
+    if (to == from) {
+      return(pl$lit(from))
+    }
+    cli_abort("{.arg by} must not be zero.")
+  }
+  if ((to - from) * by < 0) {
+    cli_abort("Wrong sign in {.arg by} argument.")
+  }
+
+  out <- pl$int_range(start = from, end = to + sign(by), step = by)
+  if (abs(to - from) < abs(by)) {
     out <- out$first()
   }
   out

--- a/tests/testthat/test-funs_default-lazy.R
+++ b/tests/testthat/test-funs_default-lazy.R
@@ -327,6 +327,42 @@ test_that("seq() works", {
     mutate(test_pl, y = seq(1, 4, by = 2)),
     mutate(test_df, y = seq(1, 4, by = 2))
   )
+  expect_equal_lazy(
+    mutate(test_pl, y = seq(1, 2)),
+    mutate(test_df, y = seq(1, 2))
+  )
+
+  test_df <- tibble(x = 1:4)
+  test_pl <- as_polars_lf(test_df)
+  expect_equal_lazy(
+    mutate(test_pl, y = seq(10, 1, by = -3)),
+    mutate(test_df, y = seq(10, 1, by = -3))
+  )
+
+  test_df <- tibble(x = 1:5)
+  test_pl <- as_polars_lf(test_df)
+  expect_equal_lazy(
+    mutate(test_pl, y = seq(5, 1)),
+    mutate(test_df, y = seq(5, 1))
+  )
+  expect_equal_lazy(
+    mutate(test_pl, y = seq(1, 1)),
+    mutate(test_df, y = seq(1, 1))
+  )
+
+  expect_equal_lazy(
+    mutate(test_pl, y = seq(1, 1, by = 0)),
+    mutate(test_df, y = seq(1, 1, by = 0))
+  )
+  expect_both_error(
+    mutate(test_pl, y = seq(1, 5, by = 0)),
+    mutate(test_df, y = seq(1, 5, by = 0))
+  )
+
+  expect_both_error(
+    mutate(test_pl, y = seq(1, 3, by = -1)),
+    mutate(test_df, y = seq(1, 3, by = -1))
+  )
 
   expect_error_lazy(
     expect_warning(

--- a/tests/testthat/test-funs_default.R
+++ b/tests/testthat/test-funs_default.R
@@ -323,6 +323,42 @@ test_that("seq() works", {
     mutate(test_pl, y = seq(1, 4, by = 2)),
     mutate(test_df, y = seq(1, 4, by = 2))
   )
+  expect_equal(
+    mutate(test_pl, y = seq(1, 2)),
+    mutate(test_df, y = seq(1, 2))
+  )
+
+  test_df <- tibble(x = 1:4)
+  test_pl <- as_polars_df(test_df)
+  expect_equal(
+    mutate(test_pl, y = seq(10, 1, by = -3)),
+    mutate(test_df, y = seq(10, 1, by = -3))
+  )
+
+  test_df <- tibble(x = 1:5)
+  test_pl <- as_polars_df(test_df)
+  expect_equal(
+    mutate(test_pl, y = seq(5, 1)),
+    mutate(test_df, y = seq(5, 1))
+  )
+  expect_equal(
+    mutate(test_pl, y = seq(1, 1)),
+    mutate(test_df, y = seq(1, 1))
+  )
+
+  expect_equal(
+    mutate(test_pl, y = seq(1, 1, by = 0)),
+    mutate(test_df, y = seq(1, 1, by = 0))
+  )
+  expect_both_error(
+    mutate(test_pl, y = seq(1, 5, by = 0)),
+    mutate(test_df, y = seq(1, 5, by = 0))
+  )
+
+  expect_both_error(
+    mutate(test_pl, y = seq(1, 3, by = -1)),
+    mutate(test_df, y = seq(1, 3, by = -1))
+  )
 
   expect_error(
     expect_warning(


### PR DESCRIPTION
There are some issues with the current `seq` function, fixed by this PR:

``` r
library(dplyr)
library(tidypolars)

# Adjacent endpoints were incorrectly reduced to the first value.
test_df <- tibble(x = 1:2)
test_pl <- as_polars_df(test_df)
mutate(test_df, y = seq(1, 2))
#> # A tibble: 2 × 2
#>       x     y
#>   <int> <int>
#> 1     1     1
#> 2     2     2
mutate(test_pl, y = seq(1, 2))
#> shape: (2, 2)
#> ┌─────┬─────┐
#> │ x   ┆ y   │
#> │ --- ┆ --- │
#> │ i32 ┆ i64 │
#> ╞═════╪═════╡
#> │ 1   ┆ 1   │
#> │ 2   ┆ 1   │
#> └─────┴─────┘

# A descending sequence incorrectly defaulted to by = 1.
test_df <- tibble(x = 1:3)
test_pl <- as_polars_df(test_df)
mutate(test_df, y = seq(3, 1))
#> # A tibble: 3 × 2
#>       x     y
#>   <int> <int>
#> 1     1     3
#> 2     2     2
#> 3     3     1
mutate(test_pl, y = seq(3, 1))
#> Error in `.data$with_columns()`:
#> ! Evaluation failed in `$with_columns()`.
#> Caused by error:
#> ! Evaluation failed in `$collect()`.
#> Caused by error:
#> ! lengths don't match: unable to add a column of length 0 to a DataFrame of height 3

# The exclusive Polars bound dropped the last value for negative steps.
test_df <- tibble(x = 1:4)
test_pl <- as_polars_df(test_df)
mutate(test_df, y = seq(10, 1, by = -3))
#> # A tibble: 4 × 2
#>       x     y
#>   <int> <dbl>
#> 1     1    10
#> 2     2     7
#> 3     3     4
#> 4     4     1
mutate(test_pl, y = seq(10, 1, by = -3))
#> Error in `.data$with_columns()`:
#> ! Evaluation failed in `$with_columns()`.
#> Caused by error:
#> ! Evaluation failed in `$collect()`.
#> Caused by error:
#> ! lengths don't match: unable to add a column of length 3 to a DataFrame of height 4

# A one-value range was not converted to a scalar before mutate() broadcast it.
test_df <- tibble(x = 1:5)
test_pl <- as_polars_df(test_df)
mutate(test_df, y = seq(1, 1))
#> # A tibble: 5 × 2
#>       x     y
#>   <int> <int>
#> 1     1     1
#> 2     2     1
#> 3     3     1
#> 4     4     1
#> 5     5     1
mutate(test_pl, y = seq(1, 1))
#> Error in `.data$with_columns()`:
#> ! Evaluation failed in `$with_columns()`.
#> Caused by error:
#> ! Evaluation failed in `$collect()`.
#> Caused by error:
#> ! Invalid operation: Series y, length 1 doesn't match the DataFrame height of 5
#> 
#> If you want expression: 1.int_range([2]) to be broadcasted, ensure it is a scalar (for instance by adding '.first()').

# Base R permits by = 0 when from and to are equal
mutate(test_df, y = seq(1, 1, by = 0))
#> # A tibble: 5 × 2
#>       x     y
#>   <int> <dbl>
#> 1     1     1
#> 2     2     1
#> 3     3     1
#> 4     4     1
#> 5     5     1
mutate(test_pl, y = seq(1, 1, by = 0))
#> Error in `.data$with_columns()`:
#> ! Evaluation failed in `$with_columns()`.
#> Caused by error:
#> ! Evaluation failed in `$collect()`.
#> Caused by error:
#> ! step must not be zero

# A step pointing away from to should produce a wrong-sign error.
mutate(test_df, y = seq(1, 3, by = -1))
#> Error in `mutate()`:
#> ℹ In argument: `y = seq(1, 3, by = -1)`.
#> Caused by error in `seq.default()`:
#> ! wrong sign in 'by' argument
mutate(test_pl, y = seq(1, 3, by = -1))
#> Error in `.data$with_columns()`:
#> ! Evaluation failed in `$with_columns()`.
#> Caused by error:
#> ! Evaluation failed in `$collect()`.
#> Caused by error:
#> ! lengths don't match: unable to add a column of length 0 to a DataFrame of height 5
```