### PR TITLE
fix: Fix nested `where()` expressions in `tidy-select`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
 
 ## Bug fixes
 
+* Nested `where()` expressions now select columns using their actual
+  types (#379, @Yousa-Mirage).
+
 * `arrange()` no longer modifies its input, which could cause unary `-` expressions in later operations
   to produce incorrect results (#374, @Yousa-Mirage).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,15 +9,15 @@
 
 ## Bug fixes
 
-* Nested `where()` expressions now select columns using their actual
-  types (#379, @Yousa-Mirage).
+* Fix `where()` when nested in `c()` or interacting with various boolean operators
+  (#379, @Yousa-Mirage).
 
 * `arrange()` no longer modifies its input, which could cause unary `-` expressions in later operations
   to produce incorrect results (#374, @Yousa-Mirage).
 
 * `arrange()` now errors consistently with `dplyr` when unary `-` is applied to unsupported types such as
   character columns (#374, @Yousa-Mirage).
-  
+
 * Fix `distinct()` on grouped data to include grouping variables in the distinct keys,
   retain grouping columns, and preserve grouping metadata (#376, @Yousa-Mirage).
 

--- a/R/utils-tidyselect.R
+++ b/R/utils-tidyselect.R
@@ -57,9 +57,24 @@ tidyselect_new_vars <- function(.cols, new_vars) {
   NULL
 }
 
+find_where_calls <- function(expr) {
+  if (!is_call(expr)) {
+    return(list())
+  }
+
+  nested_calls <- unlist(
+    lapply(call_args(expr), find_where_calls),
+    recursive = FALSE
+  )
+  if (identical(call_name(expr), "where")) {
+    nested_calls <- c(list(expr), nested_calls)
+  }
+
+  nested_calls
+}
+
 # When where() is in the dots, then we need to know the type of each variable.
-# This is done by creating a one-row DataFrame with the existing schema and
-# convert it to a tibble.
+# This is done by creating a zero-row tibble that preserves the existing schema.
 #
 # This is very expensive when there are hundreds or thousands of columns, so
 # we only do it when there's a where() call.
@@ -70,13 +85,7 @@ build_data_context <- function(.data, ..., cols = NULL) {
   if (!is.null(cols) && !is.null(quo_get_expr(cols))) {
     dots <- append(dots, quo_get_expr(cols))
   }
-  any_is_where <- any(
-    vapply(
-      dots,
-      function(x) is_call(x, "where"),
-      FUN.VALUE = logical(1)
-    )
-  )
+  any_is_where <- any(lengths(lapply(dots, find_where_calls)) > 0)
 
   if (!any_is_where) {
     out <- rlang::set_names(
@@ -96,14 +105,15 @@ build_data_context <- function(.data, ..., cols = NULL) {
 #' @noRd
 check_where_arg <- function(...) {
   exprs <- get_dots(...)
-  for (i in seq_along(exprs)) {
-    tmp <- safe_deparse(exprs[[i]])
-    if (!startsWith(tmp, "where(")) {
-      next
-    }
-    tmp <- gsub("^where\\(", "", tmp)
-    tmp <- gsub("\\)$", "", tmp)
-    if (!startsWith(tmp, "is.")) {
+  where_calls <- unlist(
+    lapply(exprs, find_where_calls),
+    recursive = FALSE
+  )
+  for (where_call in where_calls) {
+    args <- call_args(where_call)
+    valid_predicate <- length(args) > 0 &&
+      startsWith(safe_deparse(args[[1]]), "is.")
+    if (!valid_predicate) {
       cli_abort(
         "{.fn where} can only take {.fn is.*} functions (like {.fn is.numeric}).",
         call = caller_env(2)

--- a/R/utils-tidyselect.R
+++ b/R/utils-tidyselect.R
@@ -66,7 +66,7 @@ find_where_calls <- function(expr) {
     lapply(call_args(expr), find_where_calls),
     recursive = FALSE
   )
-  if (identical(call_name(expr), "where")) {
+  if (identical(call_fn(expr), tidyselect::where)) {
     nested_calls <- c(list(expr), nested_calls)
   }
 
@@ -105,10 +105,7 @@ build_data_context <- function(.data, ..., cols = NULL) {
 #' @noRd
 check_where_arg <- function(...) {
   exprs <- get_dots(...)
-  where_calls <- unlist(
-    lapply(exprs, find_where_calls),
-    recursive = FALSE
-  )
+  where_calls <- unlist(lapply(exprs, find_where_calls), recursive = FALSE)
   for (where_call in where_calls) {
     args <- call_args(where_call)
     valid_predicate <- length(args) > 0 &&

--- a/tests/testthat/_snaps/select-lazy.md
+++ b/tests/testthat/_snaps/select-lazy.md
@@ -17,3 +17,11 @@
       Error in `select()`:
       ! `where()` can only take `is.*()` functions (like `is.numeric()`).
 
+# nested `where()` predicates are checked
+
+    Code
+      current$collect()
+    Condition
+      Error in `select()`:
+      ! `where()` can only take `is.*()` functions (like `is.numeric()`).
+

--- a/tests/testthat/_snaps/select.md
+++ b/tests/testthat/_snaps/select.md
@@ -17,3 +17,11 @@
       Error in `select()`:
       ! `where()` can only take `is.*()` functions (like `is.numeric()`).
 
+# nested `where()` predicates are checked
+
+    Code
+      select(test_pl, c(where(~ mean(.x) > 3.5)))
+    Condition
+      Error in `select()`:
+      ! `where()` can only take `is.*()` functions (like `is.numeric()`).
+

--- a/tests/testthat/test-across-lazy.R
+++ b/tests/testthat/test-across-lazy.R
@@ -473,6 +473,22 @@ test_that("need to specify .cols (either named or unnamed)", {
   )
 })
 
+test_that("nested `where()` selects columns by type", {
+  test_df <- tibble(
+    x = 1:3,
+    y = letters[1:3],
+    z = c(-5L, 0L, 10L)
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |>
+      mutate(across(c(where(is.numeric)), \(x) x * 2)),
+    test_df |>
+      mutate(across(c(where(is.numeric)), \(x) x * 2))
+  )
+})
+
 test_that(".by works with across() and everything()", {
   test_df <- head(mtcars, n = 5)
   test_pl <- as_polars_lf(test_df)

--- a/tests/testthat/test-across.R
+++ b/tests/testthat/test-across.R
@@ -469,6 +469,22 @@ test_that("need to specify .cols (either named or unnamed)", {
   )
 })
 
+test_that("nested `where()` selects columns by type", {
+  test_df <- tibble(
+    x = 1:3,
+    y = letters[1:3],
+    z = c(-5L, 0L, 10L)
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |>
+      mutate(across(c(where(is.numeric)), \(x) x * 2)),
+    test_df |>
+      mutate(across(c(where(is.numeric)), \(x) x * 2))
+  )
+})
+
 test_that(".by works with across() and everything()", {
   test_df <- head(mtcars, n = 5)
   test_pl <- as_polars_df(test_df)

--- a/tests/testthat/test-select-lazy.R
+++ b/tests/testthat/test-select-lazy.R
@@ -124,6 +124,60 @@ test_that("select helpers work", {
   )
 })
 
+test_that("nested `where()` helpers work", {
+  test_df <- tibble(
+    x = 1:3,
+    y = c("a", "b", "c"),
+    z = c(TRUE, FALSE, TRUE),
+    w = c(1.5, 2.5, 3.5)
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    select(test_pl, c(where(is.numeric), y)),
+    select(test_df, c(where(is.numeric), y))
+  )
+
+  expect_equal_lazy(
+    select(test_pl, !where(is.character)),
+    select(test_df, !where(is.character))
+  )
+
+  expect_equal_lazy(
+    select(test_pl, where(is.numeric) & starts_with("x")),
+    select(test_df, where(is.numeric) & starts_with("x"))
+  )
+
+  expect_equal_lazy(
+    select(test_pl, c(tidyselect::where(is.logical))),
+    select(test_df, c(tidyselect::where(is.logical)))
+  )
+})
+
+test_that("nested `where()` uses column types for empty data", {
+  test_df <- tibble(
+    x = numeric(),
+    y = character(),
+    z = logical()
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    select(test_pl, c(where(is.logical))),
+    select(test_df, c(where(is.logical)))
+  )
+})
+
+test_that("nested `where()` predicates are checked", {
+  test_df <- tibble(x = 1:3)
+  test_pl <- as_polars_lf(test_df)
+
+  expect_snapshot_lazy(
+    select(test_pl, c(where(~ mean(.x) > 3.5))),
+    error = TRUE
+  )
+})
+
 test_that("renaming in select works", {
   test_df <- as_tibble(iris)
   test_pl <- as_polars_lf(test_df)

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -120,6 +120,60 @@ test_that("select helpers work", {
   )
 })
 
+test_that("nested `where()` helpers work", {
+  test_df <- tibble(
+    x = 1:3,
+    y = c("a", "b", "c"),
+    z = c(TRUE, FALSE, TRUE),
+    w = c(1.5, 2.5, 3.5)
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    select(test_pl, c(where(is.numeric), y)),
+    select(test_df, c(where(is.numeric), y))
+  )
+
+  expect_equal(
+    select(test_pl, !where(is.character)),
+    select(test_df, !where(is.character))
+  )
+
+  expect_equal(
+    select(test_pl, where(is.numeric) & starts_with("x")),
+    select(test_df, where(is.numeric) & starts_with("x"))
+  )
+
+  expect_equal(
+    select(test_pl, c(tidyselect::where(is.logical))),
+    select(test_df, c(tidyselect::where(is.logical)))
+  )
+})
+
+test_that("nested `where()` uses column types for empty data", {
+  test_df <- tibble(
+    x = numeric(),
+    y = character(),
+    z = logical()
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    select(test_pl, c(where(is.logical))),
+    select(test_df, c(where(is.logical)))
+  )
+})
+
+test_that("nested `where()` predicates are checked", {
+  test_df <- tibble(x = 1:3)
+  test_pl <- as_polars_df(test_df)
+
+  expect_snapshot(
+    select(test_pl, c(where(~ mean(.x) > 3.5))),
+    error = TRUE
+  )
+})
+
 test_that("renaming in select works", {
   test_df <- as_tibble(iris)
   test_pl <- as_polars_df(test_df)


### PR DESCRIPTION
There are several issues with nested `where()` expressions in `tidy-select` and this PR fixed them.

Recursively detect nested `where()` calls so `tidy-select` uses the real column schema and consistently validates predicates at any nesting level. More comprehensive tests have been added.

``` r
library(dplyr)
library(tidypolars)

test_df <- tibble(
  x = 1:3,
  y = c("a", "b", "c"),
  z = c(TRUE, FALSE, TRUE)
)
test_pl <- as_polars_df(test_df)

select(test_df, c(where(is.numeric), y))
#> # A tibble: 3 × 2
#>       x y    
#>   <int> <chr>
#> 1     1 a    
#> 2     2 b    
#> 3     3 c
select(test_pl, c(where(is.numeric), y))
#> shape: (3, 1)
#> ┌─────┐
#> │ y   │
#> │ --- │
#> │ str │
#> ╞═════╡
#> │ a   │
#> │ b   │
#> │ c   │
#> └─────┘

select(test_df, c(where(is.logical)))
#> # A tibble: 3 × 1
#>   z    
#>   <lgl>
#> 1 TRUE 
#> 2 FALSE
#> 3 TRUE
select(test_pl, c(where(is.logical)))
#> shape: (3, 3)
#> ┌─────┬─────┬───────┐
#> │ x   ┆ y   ┆ z     │
#> │ --- ┆ --- ┆ ---   │
#> │ i32 ┆ str ┆ bool  │
#> ╞═════╪═════╪═══════╡
#> │ 1   ┆ a   ┆ true  │
#> │ 2   ┆ b   ┆ false │
#> │ 3   ┆ c   ┆ true  │
#> └─────┴─────┴───────┘

select(test_df, !where(is.character))
#> # A tibble: 3 × 2
#>       x z    
#>   <int> <lgl>
#> 1     1 TRUE 
#> 2     2 FALSE
#> 3     3 TRUE
select(test_pl, !where(is.character))
#> shape: (3, 3)
#> ┌─────┬─────┬───────┐
#> │ x   ┆ y   ┆ z     │
#> │ --- ┆ --- ┆ ---   │
#> │ i32 ┆ str ┆ bool  │
#> ╞═════╪═════╪═══════╡
#> │ 1   ┆ a   ┆ true  │
#> │ 2   ┆ b   ┆ false │
#> │ 3   ┆ c   ┆ true  │
#> └─────┴─────┴───────┘

test_df |> mutate(across(c(where(is.numeric)), \(x) x * 2))
#> # A tibble: 3 × 3
#>       x y     z    
#>   <dbl> <chr> <lgl>
#> 1     2 a     TRUE 
#> 2     4 b     FALSE
#> 3     6 c     TRUE
test_pl |> mutate(across(c(where(is.numeric)), \(x) x * 2))
#> shape: (3, 3)
#> ┌─────┬─────┬───────┐
#> │ x   ┆ y   ┆ z     │
#> │ --- ┆ --- ┆ ---   │
#> │ i32 ┆ str ┆ bool  │
#> ╞═════╪═════╪═══════╡
#> │ 1   ┆ a   ┆ true  │
#> │ 2   ┆ b   ┆ false │
#> │ 3   ┆ c   ┆ true  │
#> └─────┴─────┴───────┘
```
