### PR TITLE
chore: Improve `justfile` and ignore `test.r`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,4 +17,5 @@
 
 ^jarl\.toml$
 
-^test.R$
+^test\.R$
+^test\.r$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,6 +16,7 @@
 ^flir$
 
 ^jarl\.toml$
+^justfile$
 
 ^test\.R$
 ^test\.r$

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ inst/doc
 /doc/
 /Meta/
 
-^test.R$
+/test.R
+/test.r

--- a/justfile
+++ b/justfile
@@ -2,20 +2,18 @@ _default:
     just --list
 
 document:
-  Rscript -e 'devtools::document()'
+    Rscript -e 'devtools::document()'
 
-test:
-  Rscript -e 'devtools::test()'
+test filter="":
+    Rscript -e 'devtools::test(filter = commandArgs(TRUE)[[1]])' {{ quote(filter) }}
 
 lint:
-  jarl check .
+    jarl check .
+    air format . --check
 
 format:
-  air format .
+    air format .
 
 lint-format:
-  jarl check .
-  air format .
-
-
-
+    jarl check .
+    air format .

--- a/justfile
+++ b/justfile
@@ -9,7 +9,6 @@ test filter="":
 
 lint:
     jarl check .
-    air format . --check
 
 format:
     air format .


### PR DESCRIPTION
Hi. I just try to ignore both `test.R` and `test.r`. And I formatted the `justfile` with https://github.com/nefrob/vscode-just.

I also added an argument `filter` to `just test`. Now `just test` can run all tests and `just test select` will run `devtools::test(filter = "select")`, so we can conveniently run the tests of a certain file.