### PR TITLE
fix: Ensure that `pivot_wider()` errors when some keys are specified in both `id_cols` and other arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     dplyr (> 1.1.4),
     glue,
     lifecycle,
-    polars (>= 1.13.0),
+    polars (>= 1.14.0),
     rlang (>= 1.1.0),
     tidyr,
     tidyselect,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tidypolars (development)
 
+`tidypolars` requires `polars` >= 1.14.0.
+
 ## New features
 
 * Clearer error messages in many cases (#370).

--- a/R/pivot_wider.R
+++ b/R/pivot_wider.R
@@ -92,10 +92,33 @@ pivot_wider.polars_data_frame <- function(
   data_names <- names(data)
   value_vars <- tidyselect_named_arg(data, rlang::enquo(values_from))
   names_vars <- tidyselect_named_arg(data, rlang::enquo(names_from))
-  id_cols <- setdiff(
-    tidyselect_named_arg(data, rlang::enquo(id_cols)),
-    c(value_vars, names_vars)
+
+  id_cols_is_everything <- identical(
+    quo_get_expr(enquo(id_cols)),
+    expr(everything())
   )
+  id_cols <- tidyselect_named_arg(data, rlang::enquo(id_cols))
+
+  in_name_and_id_cols <- dplyr::intersect(id_cols, names_vars)
+  if (!id_cols_is_everything && length(in_name_and_id_cols) > 0) {
+    cli_abort(
+      c(
+        "{.arg id_cols} can't select a column already selected by {.arg names_from}.",
+        "i" = "Column{?s} {.arg {in_name_and_id_cols}} ha{?s/ve} already been selected."
+      )
+    )
+  }
+  in_value_and_id_cols <- dplyr::intersect(id_cols, value_vars)
+  if (!id_cols_is_everything && length(in_value_and_id_cols) > 0) {
+    cli_abort(
+      c(
+        "{.arg id_cols} can't select a column already selected by {.arg values_from}.",
+        "i" = "Column{?s} {.arg {in_value_and_id_cols}} ha{?s/ve} already been selected."
+      )
+    )
+  }
+
+  id_cols <- setdiff(id_cols, c(value_vars, names_vars))
   id_vars <- id_cols %||% data_names[!data_names %in% c(value_vars, names_vars)]
 
   if (length(value_vars) == 0) {

--- a/tests/testthat/_snaps/pivot_wider-lazy.md
+++ b/tests/testthat/_snaps/pivot_wider-lazy.md
@@ -28,7 +28,7 @@
       
       	---> FAILED HERE RESOLVING THIS_NODE <---
       AGGREGATE[maintain_order: false]
-        [col("val").filter([(col("key")) ==v ("a")].all_horizontal([[(col("key_2")) ==v ("c")]])).item(allow_empty=true).alias("{"a","c"}"), col("val").filter([(col("key")) ==v ("b")].all_horizontal([[(col("key_2")) ==v ("d")]])).item(allow_empty=true).alias("{"b","d"}")] BY [col("a_c")]
+        [col("val").filter((col("key") ==v "a") & (col("key_2") ==v "c")).item(allow_empty=true).alias("{"a","c"}"), col("val").filter((col("key") ==v "b") & (col("key_2") ==v "d")).item(allow_empty=true).alias("{"b","d"}")] BY [col("a_c")]
         FROM
         DF ["a_c", "key", "key_2", "val"]; PROJECT */4 COLUMNS
 
@@ -71,20 +71,36 @@
     Code
       current$collect()
     Condition
-      Error in `current$collect()`:
-      ! Evaluation failed in `$collect()`.
-      Caused by error:
-      ! at least one key is required in a group_by operation
+      Error in `pivot_wider()`:
+      ! `id_cols` can't select a column already selected by `names_from`.
+      i Column `name` has already been selected.
 
 ---
 
     Code
       current$collect()
     Condition
-      Error in `current$collect()`:
-      ! Evaluation failed in `$collect()`.
-      Caused by error:
-      ! at least one key is required in a group_by operation
+      Error in `pivot_wider()`:
+      ! `id_cols` can't select a column already selected by `values_from`.
+      i Column `value` has already been selected.
+
+---
+
+    Code
+      current$collect()
+    Condition
+      Error in `pivot_wider()`:
+      ! `id_cols` can't select a column already selected by `names_from`.
+      i Columns `name` and `value` have already been selected.
+
+---
+
+    Code
+      current$collect()
+    Condition
+      Error in `pivot_wider()`:
+      ! `id_cols` can't select a column already selected by `values_from`.
+      i Columns `name` and `value` have already been selected.
 
 # dots must be empty
 

--- a/tests/testthat/_snaps/pivot_wider.md
+++ b/tests/testthat/_snaps/pivot_wider.md
@@ -67,7 +67,8 @@
       pivot_wider(test_pl, id_cols = name, names_from = name, values_from = value)
     Condition
       Error in `pivot_wider()`:
-      ! at least one key is required in a group_by operation
+      ! `id_cols` can't select a column already selected by `names_from`.
+      i Column `name` has already been selected.
 
 ---
 
@@ -75,7 +76,27 @@
       pivot_wider(test_pl, id_cols = value, names_from = name, values_from = value)
     Condition
       Error in `pivot_wider()`:
-      ! at least one key is required in a group_by operation
+      ! `id_cols` can't select a column already selected by `values_from`.
+      i Column `value` has already been selected.
+
+---
+
+    Code
+      pivot_wider(test_pl, id_cols = c(name, value), names_from = c(name, value))
+    Condition
+      Error in `pivot_wider()`:
+      ! `id_cols` can't select a column already selected by `names_from`.
+      i Columns `name` and `value` have already been selected.
+
+---
+
+    Code
+      pivot_wider(test_pl, id_cols = c(name, value), names_from = NULL, values_from = c(
+        name, value))
+    Condition
+      Error in `pivot_wider()`:
+      ! `id_cols` can't select a column already selected by `values_from`.
+      i Columns `name` and `value` have already been selected.
 
 # dots must be empty
 

--- a/tests/testthat/test-pivot_wider-lazy.R
+++ b/tests/testthat/test-pivot_wider-lazy.R
@@ -310,6 +310,23 @@ test_that("`id_cols` can't select columns from `names_from` or `values_from`", {
     ),
     error = TRUE
   )
+  expect_snapshot_lazy(
+    pivot_wider(
+      test_pl,
+      id_cols = c(name, value),
+      names_from = c(name, value)
+    ),
+    error = TRUE
+  )
+  expect_snapshot_lazy(
+    pivot_wider(
+      test_pl,
+      id_cols = c(name, value),
+      names_from = NULL,
+      values_from = c(name, value)
+    ),
+    error = TRUE
+  )
 })
 
 test_that("unsupported args throw warning", {

--- a/tests/testthat/test-pivot_wider.R
+++ b/tests/testthat/test-pivot_wider.R
@@ -306,6 +306,23 @@ test_that("`id_cols` can't select columns from `names_from` or `values_from`", {
     ),
     error = TRUE
   )
+  expect_snapshot(
+    pivot_wider(
+      test_pl,
+      id_cols = c(name, value),
+      names_from = c(name, value)
+    ),
+    error = TRUE
+  )
+  expect_snapshot(
+    pivot_wider(
+      test_pl,
+      id_cols = c(name, value),
+      names_from = NULL,
+      values_from = c(name, value)
+    ),
+    error = TRUE
+  )
 })
 
 test_that("unsupported args throw warning", {


### PR DESCRIPTION
Fixes #388 