### PR TITLE
fix: Fix `%>%` translation for unnamed arguments and nested dots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@
 * `grepl()` now returns `FALSE` for `NA` inputs, like base R (it used to return `NA`)
   (#384).
 
+* Fix `%>%` with unnamed arguments and nested `.` placeholders (#390, @Yousa-Mirage).
+
 * R expressions using `:` now resolve local variables from the calling environment (#381, @Yousa-Mirage).
 
 * Fix `where()` when nested in `c()` or interacting with various boolean operators

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -608,25 +608,16 @@ translate <- function(
           }
 
           has_dot <- any(vapply(
-            rhs,
+            call_args(rhs),
             function(x) is.symbol(x) && identical(x, sym(".")),
             FUN.VALUE = logical(1)
           ))
 
-          if (has_dot) {
-            new_rhs <- replace_dot(rhs, lhs)
-          } else {
-            ### I want to insert `lhs` as first arg so first I remove all args
-            ### in the original call (after saving them), and then I insert the
-            ### new args with `lhs` first.
-            existing_args <- call_args(rhs)
-            remove_args <- rep_named(names(existing_args), list(zap()))
-            new_args <- append(list(lhs), existing_args)
-            new_rhs <- rhs
-            if (length(remove_args) > 0) {
-              new_rhs <- call_modify(new_rhs, !!!remove_args)
-            }
-            new_rhs <- call_modify(new_rhs, !!!new_args)
+          new_rhs <- replace_dot(rhs, lhs)
+          if (!has_dot) {
+            new_rhs <- as.call(
+              append(as.list(new_rhs), list(lhs), after = 1L)
+            )
           }
 
           out <- translate(

--- a/tests/testthat/_snaps/show_query-lazy.md
+++ b/tests/testthat/_snaps/show_query-lazy.md
@@ -175,6 +175,36 @@
       │ 20.090625 ┆ 4.0 ┆ 121.0 ┆ 109.0 ┆ … ┆ 1.0 ┆ 0.40625 ┆ 4.0  ┆ 2.0  │
       └───────────┴─────┴───────┴───────┴───┴─────┴─────────┴──────┴──────┘
 
+# show_query() records magrittr pipe translations
+
+    Code
+      current$collect()
+    Output
+      as_polars_lf(tibble(x = 1:3))$
+        with_columns(
+          rounded = pl$col("x")$round(decimals = 2),
+          in_range = pl$col("x")$
+            is_between(
+              lower_bound = pl$when(pl$col("x")$has_nulls())$
+                then(NA)$
+                otherwise(pl$col("x")$min()),
+              upper_bound = pl$when(pl$col("x")$has_nulls())$
+                then(NA)$
+                otherwise(pl$col("x")$max()),
+              closed = "both"
+            )
+        )
+      shape: (3, 3)
+      ┌─────┬─────────┬──────────┐
+      │ x   ┆ rounded ┆ in_range │
+      │ --- ┆ ---     ┆ ---      │
+      │ i32 ┆ i32     ┆ bool     │
+      ╞═════╪═════════╪══════════╡
+      │ 1   ┆ 1       ┆ true     │
+      │ 2   ┆ 2       ┆ true     │
+      │ 3   ┆ 3       ┆ true     │
+      └─────┴─────────┴──────────┘
+
 # user-defined functions returning polars expressions are recorded
 
     Code

--- a/tests/testthat/_snaps/show_query.md
+++ b/tests/testthat/_snaps/show_query.md
@@ -93,6 +93,26 @@
             otherwise(pl$col("am")$mean())
         )
 
+# show_query() records magrittr pipe translations
+
+    Code
+      show_query(query)
+    Output
+      as_polars_df(tibble(x = 1:3))$
+        with_columns(
+          rounded = pl$col("x")$round(decimals = 2),
+          in_range = pl$col("x")$
+            is_between(
+              lower_bound = pl$when(pl$col("x")$has_nulls())$
+                then(NA)$
+                otherwise(pl$col("x")$min()),
+              upper_bound = pl$when(pl$col("x")$has_nulls())$
+                then(NA)$
+                otherwise(pl$col("x")$max()),
+              closed = "both"
+            )
+        )
+
 # user-defined functions returning polars expressions are recorded
 
     Code

--- a/tests/testthat/test-magrittr-pipe-lazy.R
+++ b/tests/testthat/test-magrittr-pipe-lazy.R
@@ -14,6 +14,10 @@ test_that("%>% works in expression without '.'", {
     test_pl |> mutate(y = x %>% mean(na.rm = TRUE)),
     test_df |> mutate(y = x %>% mean(na.rm = TRUE))
   )
+  expect_equal_lazy(
+    test_pl |> mutate(y = x %>% round(2)),
+    test_df |> mutate(y = x %>% round(2))
+  )
 })
 
 test_that("%>% works in expression with '.'", {
@@ -23,6 +27,24 @@ test_that("%>% works in expression with '.'", {
   expect_equal_lazy(
     test_pl |> mutate(y = x %>% mean(x = .)),
     test_df |> mutate(y = x %>% mean(x = .))
+  )
+  expect_equal_lazy(
+    test_pl |> mutate(y = x %>% round(., 2)),
+    test_df |> mutate(y = x %>% round(., 2))
+  )
+})
+
+test_that("%>% replaces nested '.'", {
+  test_df <- tibble(x = 1:3)
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |> mutate(y = x %>% between(left = min(.), right = max(.))),
+    test_df |> mutate(y = x %>% between(left = min(.), right = max(.)))
+  )
+  expect_equal_lazy(
+    test_pl |> mutate(y = x %>% between(., left = min(.), right = max(.))),
+    test_df |> mutate(y = x %>% between(., left = min(.), right = max(.)))
   )
 })
 
@@ -43,6 +65,10 @@ test_that("chaining %>% works", {
   expect_equal_lazy(
     test_pl |> mutate(y = x %>% sqrt() %>% mean(na.rm = TRUE)),
     test_df |> mutate(y = x %>% sqrt() %>% mean(na.rm = TRUE))
+  )
+  expect_equal_lazy(
+    test_pl |> mutate(y = x %>% sqrt() %>% round(2)),
+    test_df |> mutate(y = x %>% sqrt() %>% round(2))
   )
   expect_equal_lazy(
     test_pl |> mutate(y = x %>% sqrt(x = .) %>% mean(x = ., na.rm = TRUE)),

--- a/tests/testthat/test-magrittr-pipe.R
+++ b/tests/testthat/test-magrittr-pipe.R
@@ -10,6 +10,10 @@ test_that("%>% works in expression without '.'", {
     test_pl |> mutate(y = x %>% mean(na.rm = TRUE)),
     test_df |> mutate(y = x %>% mean(na.rm = TRUE))
   )
+  expect_equal(
+    test_pl |> mutate(y = x %>% round(2)),
+    test_df |> mutate(y = x %>% round(2))
+  )
 })
 
 test_that("%>% works in expression with '.'", {
@@ -19,6 +23,24 @@ test_that("%>% works in expression with '.'", {
   expect_equal(
     test_pl |> mutate(y = x %>% mean(x = .)),
     test_df |> mutate(y = x %>% mean(x = .))
+  )
+  expect_equal(
+    test_pl |> mutate(y = x %>% round(., 2)),
+    test_df |> mutate(y = x %>% round(., 2))
+  )
+})
+
+test_that("%>% replaces nested '.'", {
+  test_df <- tibble(x = 1:3)
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |> mutate(y = x %>% between(left = min(.), right = max(.))),
+    test_df |> mutate(y = x %>% between(left = min(.), right = max(.)))
+  )
+  expect_equal(
+    test_pl |> mutate(y = x %>% between(., left = min(.), right = max(.))),
+    test_df |> mutate(y = x %>% between(., left = min(.), right = max(.)))
   )
 })
 
@@ -39,6 +61,10 @@ test_that("chaining %>% works", {
   expect_equal(
     test_pl |> mutate(y = x %>% sqrt() %>% mean(na.rm = TRUE)),
     test_df |> mutate(y = x %>% sqrt() %>% mean(na.rm = TRUE))
+  )
+  expect_equal(
+    test_pl |> mutate(y = x %>% sqrt() %>% round(2)),
+    test_df |> mutate(y = x %>% sqrt() %>% round(2))
   )
   expect_equal(
     test_pl |> mutate(y = x %>% sqrt(x = .) %>% mean(x = ., na.rm = TRUE)),

--- a/tests/testthat/test-show_query-lazy.R
+++ b/tests/testthat/test-show_query-lazy.R
@@ -99,6 +99,18 @@ test_that("show_query() works with across()", {
   expect_equal_lazy(replay_query(query), query)
 })
 
+test_that("show_query() records magrittr pipe translations", {
+  query <- tibble(x = 1:3) |>
+    as_polars_lf() |>
+    mutate(
+      rounded = x %>% round(2),
+      in_range = x %>% between(left = min(.), right = max(.))
+    )
+
+  expect_snapshot_lazy(show_query(query))
+  expect_equal_lazy(replay_query(query), query)
+})
+
 test_that("user-defined functions returning polars expressions are recorded", {
   pl_standardize <- function(x) {
     (x - x$mean()) / x$std()

--- a/tests/testthat/test-show_query.R
+++ b/tests/testthat/test-show_query.R
@@ -95,6 +95,18 @@ test_that("show_query() works with across()", {
   expect_equal(replay_query(query), query)
 })
 
+test_that("show_query() records magrittr pipe translations", {
+  query <- tibble(x = 1:3) |>
+    as_polars_df() |>
+    mutate(
+      rounded = x %>% round(2),
+      in_range = x %>% between(left = min(.), right = max(.))
+    )
+
+  expect_snapshot(show_query(query))
+  expect_equal(replay_query(query), query)
+})
+
 test_that("user-defined functions returning polars expressions are recorded", {
   pl_standardize <- function(x) {
     (x - x$mean()) / x$std()


### PR DESCRIPTION
The `%>%` translation for unnamed arguments and nested `.` placeholders will raise error. This PR fixed this and added some new tests, including tests for `show_query`.

``` r
library(dplyr)
library(tidypolars)
library(magrittr)

test_df <- tibble(x = c(1.234, 2.345))
test_pl <- as_polars_df(test_df)

test_df %>% mutate(y = x %>% round(2))
#> # A tibble: 2 × 2
#>       x     y
#>   <dbl> <dbl>
#> 1  1.23  1.23
#> 2  2.35  2.35
test_pl %>% mutate(y = x %>% round(2))
#> Error in `call_modify()`:
#> ! Zap sentinels can't be unnamed

test_df %>% mutate(y = x %>% round(digits = length(.)))
#> # A tibble: 2 × 2
#>       x     y
#>   <dbl> <dbl>
#> 1  1.23  1.23
#> 2  2.35  2.35
test_pl %>% mutate(y = x %>% round(digits = length(.)))
#> Error in `mutate()`:
#> ! Error while running function `round()` in Polars.
#> ✖ Evaluation failed in `$round()`.
```