### PR TITLE
fix: Fix `relocate()` with multiple `.before` and `.after` selections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
 
 ## Bug fixes
 
+* Fix `relocate()` to use the leftmost and rightmost selected columns for
+  `.before` and `.after` for consistency with `dplyr` (#392, @Yousa-Mirage).
+
 * Multiple fixes to improve compatibility with `stringr` for the following functions:
   `fixed()`, `regex()`, `str_extract_all()`, `str_pad()`, `str_split()`, `str_split_i()`,
   `str_trunc()`, `word()`. (#384)

--- a/R/relocate.R
+++ b/R/relocate.R
@@ -68,7 +68,7 @@ relocate.polars_data_frame <- function(
     limit <- if (is.null(.before)) {
       0
     } else {
-      which(names_data == .before[1]) - 1
+      min(match(.before, names_data)) - 1
     }
     lhs <- names_data[seq_len(limit)]
     lhs <- lhs[which(lhs %in% not_moving)]
@@ -79,7 +79,7 @@ relocate.polars_data_frame <- function(
     limit <- if (is.null(.after)) {
       ncol(.data)
     } else {
-      which(names_data == .after[length(.after)])
+      max(match(.after, names_data))
     }
     lhs <- names_data[seq_len(limit)]
     lhs <- lhs[which(lhs %in% not_moving)]

--- a/tests/testthat/test-relocate-lazy.R
+++ b/tests/testthat/test-relocate-lazy.R
@@ -40,6 +40,28 @@ test_that(".before and .after can be quoted or unquoted", {
   )
 })
 
+test_that("multiple destination columns use their positions", {
+  test_df <- tibble(
+    a = 1,
+    b = 2,
+    c = 3,
+    d = 4,
+    e = 5,
+    moved = 6
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |> relocate(moved, .before = c(d, b)),
+    test_df |> relocate(moved, .before = c(d, b))
+  )
+
+  expect_equal_lazy(
+    test_pl |> relocate(moved, .after = c(d, b)),
+    test_df |> relocate(moved, .after = c(d, b))
+  )
+})
+
 test_that("select helpers are also available", {
   test_df <- as_tibble(mtcars)
   test_pl <- as_polars_lf(test_df)

--- a/tests/testthat/test-relocate.R
+++ b/tests/testthat/test-relocate.R
@@ -36,6 +36,28 @@ test_that(".before and .after can be quoted or unquoted", {
   )
 })
 
+test_that("multiple destination columns use their positions", {
+  test_df <- tibble(
+    a = 1,
+    b = 2,
+    c = 3,
+    d = 4,
+    e = 5,
+    moved = 6
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |> relocate(moved, .before = c(d, b)),
+    test_df |> relocate(moved, .before = c(d, b))
+  )
+
+  expect_equal(
+    test_pl |> relocate(moved, .after = c(d, b)),
+    test_df |> relocate(moved, .after = c(d, b))
+  )
+})
+
 test_that("select helpers are also available", {
   test_df <- as_tibble(mtcars)
   test_pl <- as_polars_df(test_df)


### PR DESCRIPTION
Fix `relocate()` to determine `.before` and `.after` positions from the leftmost and rightmost selected columns in the original data, matching `dplyr` regardless of tidy-select order.

Before:

``` r
library(dplyr)
library(tidypolars)

test_df <- tibble(
  a = 1, b = 2, c = 3, d = 4, e = 5, moved = 6
)
test_pl <- as_polars_df(test_df)

relocate(test_df, moved, .before = c(d, b)) |> names()
#> [1] "a"     "moved" "b"     "c"     "d"     "e"
relocate(test_pl, moved, .before = c(d, b)) |> names()
#> [1] "a"     "b"     "c"     "moved" "d"     "e"

relocate(test_df, moved, .after = c(d, b)) |> names()
#> [1] "a"     "b"     "c"     "d"     "moved" "e"
relocate(test_pl, moved, .after = c(d, b)) |> names()
#> [1] "a"     "b"     "moved" "c"     "d"     "e"
```