### PR TITLE
fix: Complete parquet and CSV argument validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
 
 ## Bug fixes
 
+* Allow the Polars-supported "prefiltered" Parquet scan strategy and
+  "never" CSV quote style in the corresponding wrappers (#393, @Yousa-Mirage).
+
 * Multiple fixes to improve compatibility with `stringr` for the following functions:
   `fixed()`, `regex()`, `str_extract_all()`, `str_pad()`, `str_split()`, `str_split_i()`,
   `str_trunc()`, `word()`. (#384)

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,21 +14,23 @@
 
 * Improved the performance of `pivot_longer()` by no longer sorting its
   output (#395, @Yousa-Mirage).
-  
+
 * Added support for the `name` argument in `pull()` (#391, @Yousa-Mirage).
 
 * Allow `slice_sample()` with `n > nrow(data)` and `prop > 1` (#394, @Yousa-Mirage).
+
+* Allow `parallel = "prefiltered"` in `scan_parquet_polars()` and
+  `read_parquet_polars()` (#393, @Yousa-Mirage).
+
+* Allow `quote_style = "never"` in `sink_csv()` (#393, @Yousa-Mirage).
 
 ## Bug fixes
 
 * Fix the function name in deprecation warnings from `sink_csv()` (#393, @Yousa-Mirage).
 
-* Allow the Polars-supported "prefiltered" Parquet scan strategy and
-  "never" CSV quote style in the corresponding wrappers (#393, @Yousa-Mirage).
-
 * Fix grouped `slice_head()`, `slice_tail()`, and `slice_sample()` for zero-size
   samples (#394, @Yousa-Mirage).
-  
+
 * Fix `relocate()` to use the leftmost and rightmost selected columns for
   `.before` and `.after` for consistency with `dplyr` (#392, @Yousa-Mirage).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 ## Bug fixes
 
+* Fix the function name in deprecation warnings from `sink_csv()`.
+
 * Allow the Polars-supported "prefiltered" Parquet scan strategy and
   "never" CSV quote style in the corresponding wrappers (#393, @Yousa-Mirage).
 

--- a/R/read_scan.R
+++ b/R/read_scan.R
@@ -139,7 +139,7 @@ scan_parquet_polars <- function(
 ) {
   rlang::arg_match0(
     parallel,
-    values = c("auto", "columns", "row_groups", "none")
+    values = c("auto", "columns", "row_groups", "prefiltered", "none")
   )
   rlang::check_dots_empty()
 

--- a/R/sink.R
+++ b/R/sink.R
@@ -264,7 +264,7 @@ sink_csv <- function(
   if (!missing(quote)) {
     lifecycle::deprecate_warn(
       when = "0.14.0",
-      what = "sink_csv_polars(quote)",
+      what = "sink_csv(quote)",
       details = "Use `quote_char` instead."
     )
     quote_char <- quote
@@ -273,7 +273,7 @@ sink_csv <- function(
   if (!missing(null_values)) {
     lifecycle::deprecate_warn(
       when = "0.14.0",
-      what = "sink_csv_polars(null_values)",
+      what = "sink_csv(null_values)",
       details = "Use `null_value` instead."
     )
     if (missing(null_value)) {

--- a/R/sink.R
+++ b/R/sink.R
@@ -258,7 +258,7 @@ sink_csv <- function(
 
   rlang::arg_match0(
     quote_style,
-    values = c("necessary", "always", "non_numeric")
+    values = c("necessary", "always", "non_numeric", "never")
   )
 
   if (!missing(quote)) {

--- a/R/sink.R
+++ b/R/sink.R
@@ -180,6 +180,8 @@ sink_parquet <- function(
 #' * `"non_numeric"`: This puts quotes around all fields that are non-numeric.
 #'   Namely, when writing a field that does not parse as a valid float or integer,
 #'   then quotes will be used even if they aren't strictly necessary.
+#' * `"never"`: This never puts quotes around fields, even if that results in
+#'   invalid CSV data (e.g. by not quoting strings containing the separator).
 #' @param quote `r lifecycle::badge("deprecated")` Deprecated, use `quote_char`
 #' instead.
 #' @param null_values `r lifecycle::badge("deprecated")` Deprecated, use

--- a/man/sink_csv.Rd
+++ b/man/sink_csv.Rd
@@ -74,6 +74,8 @@ indistinguishable from a record with one empty field).
 \item \code{"non_numeric"}: This puts quotes around all fields that are non-numeric.
 Namely, when writing a field that does not parse as a valid float or integer,
 then quotes will be used even if they aren't strictly necessary.
+\item \code{"never"}: This never puts quotes around fields, even if that results in
+invalid CSV data (e.g. by not quoting strings containing the separator).
 }}
 
 \item{maintain_order}{Whether maintain the order the data was processed

--- a/tests/testthat/_snaps/sink.md
+++ b/tests/testthat/_snaps/sink.md
@@ -36,7 +36,7 @@
       x <- sink_csv(dat, dest, null_values = "a")
     Condition
       Warning:
-      The `null_values` argument of `sink_csv_polars()` is deprecated as of tidypolars 0.14.0.
+      The `null_values` argument of `sink_csv()` is deprecated as of tidypolars 0.14.0.
       i Use `null_value` instead.
 
 ---
@@ -45,6 +45,6 @@
       x <- sink_csv(dat, dest, quote = "a")
     Condition
       Warning:
-      The `quote` argument of `sink_csv_polars()` is deprecated as of tidypolars 0.14.0.
+      The `quote` argument of `sink_csv()` is deprecated as of tidypolars 0.14.0.
       i Use `quote_char` instead.
 

--- a/tests/testthat/test-read-write.R
+++ b/tests/testthat/test-read-write.R
@@ -27,6 +27,20 @@ patrick::with_parameters_test_that(
   file_format = c("ipc", "parquet")
 )
 
+test_that("parquet supports the prefiltered parallel strategy", {
+  dest <- tempfile(fileext = ".parquet")
+  write_parquet_polars(as_polars_df(mtcars), dest)
+
+  expect_s3_class(
+    scan_parquet_polars(dest, parallel = "prefiltered"),
+    "polars_lazy_frame"
+  )
+  expect_s3_class(
+    read_parquet_polars(dest, parallel = "prefiltered"),
+    "polars_data_frame"
+  )
+})
+
 # Can't distinguish integers from floats
 test_that("CSV can do a write-read roundtrip", {
   for_all(

--- a/tests/testthat/test-sink.R
+++ b/tests/testthat/test-sink.R
@@ -14,6 +14,14 @@ test_that("basic behavior with CSV", {
   expect_equal(read.csv(dest), mtcars, ignore_attr = TRUE)
 })
 
+test_that("sink_csv accepts the 'never' quote style", {
+  dest <- tempfile(fileext = ".csv")
+  as_polars_lf(tibble(x = c("a,b", "c"))) |>
+    sink_csv(dest, quote_style = "never")
+
+  expect_equal(readLines(dest), c("x", "a,b", "c"))
+})
+
 test_that("deprecated args in sink_csv()", {
   dest <- tempfile(fileext = ".csv")
   dat <- as_polars_lf(mtcars)


### PR DESCRIPTION
1. Allow `parallel = "prefiltered"` in `scan_parquet_polars()` and `read_parquet_polars()`.
2. Allow `quote_style = "never"` in `sink_csv()`.
3. Fix deprecated `sink_csv()` warnings to reference `sink_csv()` instead of `sink_csv_polars()`.

Added regression tests, snapshots, and NEWS entries.