### PR TITLE
fix: Align grouped `slice` behavior with `dplyr`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 ## Bug fixes
 
 * Fix grouped `slice_head()`, `slice_tail()`, and `slice_sample()` for zero-size
-  samples and samples larger than a group (#394, @Yousa-Mirage).
+  samples. Allow `slice_sample()` with `n > nrow(data)` and `prop > 1` (#394, @Yousa-Mirage).
 
 * Multiple fixes to improve compatibility with `stringr` for the following functions:
   `fixed()`, `regex()`, `str_extract_all()`, `str_pad()`, `str_split()`, `str_split_i()`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,10 +12,12 @@
 * Added support for `anyDuplicated()`, and for the `incomparables` and `fromLast`
   arguments of `duplicated()` (#375, @Yousa-Mirage).
 
+* Allow `slice_sample()` with `n > nrow(data)` and `prop > 1` (#394, @Yousa-Mirage).
+
 ## Bug fixes
 
 * Fix grouped `slice_head()`, `slice_tail()`, and `slice_sample()` for zero-size
-  samples. Allow `slice_sample()` with `n > nrow(data)` and `prop > 1` (#394, @Yousa-Mirage).
+  samples (#394, @Yousa-Mirage).
   
 * Fix `relocate()` to use the leftmost and rightmost selected columns for
   `.before` and `.after` for consistency with `dplyr` (#392, @Yousa-Mirage).

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@
 
 ## Bug fixes
 
+* Fix grouped `slice_head()`, `slice_tail()`, and `slice_sample()` for zero-size
+  samples and samples larger than a group (#394, @Yousa-Mirage).
+
 * Multiple fixes to improve compatibility with `stringr` for the following functions:
   `fixed()`, `regex()`, `str_extract_all()`, `str_pad()`, `str_split()`, `str_split_i()`,
   `str_trunc()`, `word()`. (#384)

--- a/R/slice.R
+++ b/R/slice.R
@@ -118,19 +118,14 @@ slice_sample.polars_data_frame <- function(
   }
 
   if (is_grouped) {
-    non_grps <- setdiff(names(.data), grps)
-    # Polars errors when sampling more rows than a group contains. Shuffling
-    # and taking the head matches dplyr's per-group truncation instead.
-    sample_expr <- if (isFALSE(replace) && !is.null(n) && isTRUE(n >= 0)) {
-      pl$all()$shuffle()$head(n)
-    } else {
-      pl$all()$sample(n = n, fraction = prop, with_replacement = replace)
-    }
-
-    out <- .data$group_by(grps, .maintain_order = mo)$agg(sample_expr)$explode(
-      non_grps,
-      empty_as_null = FALSE
-    )
+    partitions <- .data$partition_by(!!!grps)
+    sampled_partitions <- lapply(partitions, function(x) {
+      if (isFALSE(replace) && !is.null(n) && isTRUE(n >= nrow(x))) {
+        n <- nrow(x)
+      }
+      x$sample(n = n, fraction = prop, with_replacement = replace)
+    })
+    out <- bind_rows_polars(sampled_partitions)
   } else {
     out <- .data$sample(n = n, fraction = prop, with_replacement = replace)
   }

--- a/R/slice.R
+++ b/R/slice.R
@@ -118,12 +118,18 @@ slice_sample.polars_data_frame <- function(
 
   if (is_grouped) {
     temp_row <- "__tidypolars_slice_sample_row__"
-    sample_expr <- pl$struct(names(.data))$sample(
-      n = n,
-      fraction = prop,
-      with_replacement = replace,
-      shuffle = TRUE
-    )
+    row_expr <- pl$struct(names(.data))
+
+    sample_expr <- if (isFALSE(replace) && !is.null(n) && isTRUE(n >= 0)) {
+      row_expr$shuffle()$head(n)
+    } else {
+      row_expr$sample(
+        n = n,
+        fraction = prop,
+        with_replacement = replace,
+        shuffle = TRUE
+      )
+    }
 
     out <- .data$group_by(grps, .maintain_order = mo)$agg(
       sample_expr$alias(temp_row)

--- a/R/slice.R
+++ b/R/slice.R
@@ -118,18 +118,12 @@ slice_sample.polars_data_frame <- function(
 
   if (is_grouped) {
     temp_row <- "__tidypolars_slice_sample_row__"
-    row_expr <- pl$struct(names(.data))
-
-    sample_expr <- if (isFALSE(replace) && !is.null(n) && isTRUE(n >= 0)) {
-      row_expr$shuffle()$head(n)
-    } else {
-      row_expr$sample(
-        n = n,
-        fraction = prop,
-        with_replacement = replace,
-        shuffle = TRUE
-      )
-    }
+    sample_expr <- pl$struct(names(.data))$sample(
+      n = n,
+      fraction = prop,
+      with_replacement = replace,
+      shuffle = TRUE
+    )
 
     out <- .data$group_by(grps, .maintain_order = mo)$agg(
       sample_expr$alias(temp_row)

--- a/R/slice.R
+++ b/R/slice.R
@@ -28,7 +28,7 @@ slice_tail.polars_data_frame <- function(.data, ..., n, by = NULL) {
     non_grps <- setdiff(names(.data), grps)
     out <- .data$group_by(grps, .maintain_order = mo)$agg(
       pl$all()$tail(n)
-    )$explode(non_grps, empty_as_null = TRUE)$select(!!!col_order)
+    )$explode(non_grps, empty_as_null = FALSE)$select(!!!col_order)
   } else {
     out <- .data$tail(n)
   }
@@ -60,7 +60,7 @@ slice_head.polars_data_frame <- function(.data, ..., n, by = NULL) {
     non_grps <- setdiff(names(.data), grps)
     out <- .data$group_by(grps, .maintain_order = mo)$agg(
       pl$all()$head(n)
-    )$explode(non_grps, empty_as_null = TRUE)$select(!!!col_order)
+    )$explode(non_grps, empty_as_null = FALSE)$select(!!!col_order)
   } else {
     out <- .data$head(n)
   }
@@ -109,7 +109,7 @@ slice_sample.polars_data_frame <- function(
   }
   if (
     isFALSE(replace) &&
-      ((!is.null(n) && n > nrow(.data)) ||
+      ((!is_grouped && !is.null(n) && n > nrow(.data)) ||
         (!is.null(prop) && prop > 1))
   ) {
     cli_abort(
@@ -119,9 +119,18 @@ slice_sample.polars_data_frame <- function(
 
   if (is_grouped) {
     non_grps <- setdiff(names(.data), grps)
-    out <- .data$group_by(grps, .maintain_order = mo)$agg(
+    # Polars errors when sampling more rows than a group contains. Shuffling
+    # and taking the head matches dplyr's per-group truncation instead.
+    sample_expr <- if (isFALSE(replace) && !is.null(n) && isTRUE(n >= 0)) {
+      pl$all()$shuffle()$head(n)
+    } else {
       pl$all()$sample(n = n, fraction = prop, with_replacement = replace)
-    )$explode(non_grps, empty_as_null = TRUE)
+    }
+
+    out <- .data$group_by(grps, .maintain_order = mo)$agg(sample_expr)$explode(
+      non_grps,
+      empty_as_null = FALSE
+    )
   } else {
     out <- .data$sample(n = n, fraction = prop, with_replacement = replace)
   }

--- a/R/slice.R
+++ b/R/slice.R
@@ -108,37 +108,32 @@ slice_sample.polars_data_frame <- function(
     n <- 1
   }
   if (isFALSE(replace)) {
-    if (!is.null(n) && n > nrow(.data)) {
+    if (!is_grouped && !is.null(n) && n > nrow(.data)) {
       n <- nrow(.data)
-    } else if (!is.null(prop) && prop > 1) {
+    }
+    if (!is.null(prop) && prop > 1) {
       prop <- 1
     }
   }
 
   if (is_grouped) {
-    partitions <- .data$partition_by(!!!grps, maintain_order = mo)
+    temp_row <- "__tidypolars_slice_sample_row__"
+    row_expr <- pl$struct(names(.data))
 
-    if (length(partitions) == 0) {
-      out <- .data
+    sample_expr <- if (isFALSE(replace) && !is.null(n) && isTRUE(n >= 0)) {
+      row_expr$shuffle()$head(n)
     } else {
-      sampled_partitions <- lapply(partitions, function(x) {
-        sample_n <- n
-        if (
-          isFALSE(replace) &&
-            !is.null(sample_n) &&
-            isTRUE(sample_n >= nrow(x))
-        ) {
-          sample_n <- nrow(x)
-        }
-        x$sample(
-          n = sample_n,
-          fraction = prop,
-          with_replacement = replace,
-          shuffle = TRUE
-        )
-      })
-      out <- bind_rows_polars(sampled_partitions)
+      row_expr$sample(
+        n = n,
+        fraction = prop,
+        with_replacement = replace,
+        shuffle = TRUE
+      )
     }
+
+    out <- .data$group_by(grps, .maintain_order = mo)$agg(
+      sample_expr$alias(temp_row)
+    )$explode(temp_row, empty_as_null = FALSE)$select(temp_row)$unnest(temp_row)
   } else {
     out <- .data$sample(
       n = n,

--- a/R/slice.R
+++ b/R/slice.R
@@ -116,19 +116,29 @@ slice_sample.polars_data_frame <- function(
   }
 
   if (is_grouped) {
-    partitions <- .data$partition_by(!!!grps)
-    sampled_partitions <- lapply(partitions, function(x) {
-      if (isFALSE(replace) && !is.null(n) && isTRUE(n >= nrow(x))) {
-        n <- nrow(x)
-      }
-      x$sample(
-        n = n,
-        fraction = prop,
-        with_replacement = replace,
-        shuffle = TRUE
-      )
-    })
-    out <- bind_rows_polars(sampled_partitions)
+    partitions <- .data$partition_by(!!!grps, maintain_order = mo)
+
+    if (length(partitions) == 0) {
+      out <- .data
+    } else {
+      sampled_partitions <- lapply(partitions, function(x) {
+        sample_n <- n
+        if (
+          isFALSE(replace) &&
+            !is.null(sample_n) &&
+            isTRUE(sample_n >= nrow(x))
+        ) {
+          sample_n <- nrow(x)
+        }
+        x$sample(
+          n = sample_n,
+          fraction = prop,
+          with_replacement = replace,
+          shuffle = TRUE
+        )
+      })
+      out <- bind_rows_polars(sampled_partitions)
+    }
   } else {
     out <- .data$sample(
       n = n,

--- a/R/slice.R
+++ b/R/slice.R
@@ -107,14 +107,12 @@ slice_sample.polars_data_frame <- function(
   if (is.null(n) && is.null(prop)) {
     n <- 1
   }
-  if (
-    isFALSE(replace) &&
-      ((!is_grouped && !is.null(n) && n > nrow(.data)) ||
-        (!is.null(prop) && prop > 1))
-  ) {
-    cli_abort(
-      "Cannot take more rows than the total number of rows when {.code replace = FALSE}."
-    )
+  if (isFALSE(replace)) {
+    if (!is.null(n) && n > nrow(.data)) {
+      n <- nrow(.data)
+    } else if (!is.null(prop) && prop > 1) {
+      prop <- 1
+    }
   }
 
   if (is_grouped) {
@@ -123,11 +121,21 @@ slice_sample.polars_data_frame <- function(
       if (isFALSE(replace) && !is.null(n) && isTRUE(n >= nrow(x))) {
         n <- nrow(x)
       }
-      x$sample(n = n, fraction = prop, with_replacement = replace)
+      x$sample(
+        n = n,
+        fraction = prop,
+        with_replacement = replace,
+        shuffle = TRUE
+      )
     })
     out <- bind_rows_polars(sampled_partitions)
   } else {
-    out <- .data$sample(n = n, fraction = prop, with_replacement = replace)
+    out <- .data$sample(
+      n = n,
+      fraction = prop,
+      with_replacement = replace,
+      shuffle = TRUE
+    )
   }
 
   out <- if (is_grouped && missing(by)) {

--- a/tests/testthat/_snaps/show_query-lazy.md
+++ b/tests/testthat/_snaps/show_query-lazy.md
@@ -1047,6 +1047,144 @@
       │ 5.9          ┆ 3.0         ┆ 5.1          ┆ 1.8         ┆ virginica │
       └──────────────┴─────────────┴──────────────┴─────────────┴───────────┘
 
+# slice example: slice by group
+
+    Code
+      current$collect()
+    Output
+      as_polars_lf(iris)$
+        group_by(
+          "Species",
+          .maintain_order = FALSE
+        )$
+        agg(pl$all()$head(3))$
+        explode(
+          c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"),
+          empty_as_null = FALSE
+        )$
+        select(
+          "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species"
+        )$
+        with_columns(
+          pl$col("Species")$alias("__TIDYPOLARS_TEMP_SORT__1"),
+          pl$col("Sepal.Width")$alias("__TIDYPOLARS_TEMP_SORT__2")
+        )$
+        sort(
+          "__TIDYPOLARS_TEMP_SORT__1",
+          "__TIDYPOLARS_TEMP_SORT__2",
+          descending = c(FALSE, FALSE),
+          nulls_last = TRUE
+        )$
+        drop("__TIDYPOLARS_TEMP_SORT__1", "__TIDYPOLARS_TEMP_SORT__2")
+      shape: (9, 5)
+      ┌──────────────┬─────────────┬──────────────┬─────────────┬────────────┐
+      │ Sepal.Length ┆ Sepal.Width ┆ Petal.Length ┆ Petal.Width ┆ Species    │
+      │ ---          ┆ ---         ┆ ---          ┆ ---         ┆ ---        │
+      │ f64          ┆ f64         ┆ f64          ┆ f64         ┆ cat        │
+      ╞══════════════╪═════════════╪══════════════╪═════════════╪════════════╡
+      │ 4.9          ┆ 3.0         ┆ 1.4          ┆ 0.2         ┆ setosa     │
+      │ 4.7          ┆ 3.2         ┆ 1.3          ┆ 0.2         ┆ setosa     │
+      │ 5.1          ┆ 3.5         ┆ 1.4          ┆ 0.2         ┆ setosa     │
+      │ 6.9          ┆ 3.1         ┆ 4.9          ┆ 1.5         ┆ versicolor │
+      │ 7.0          ┆ 3.2         ┆ 4.7          ┆ 1.4         ┆ versicolor │
+      │ 6.4          ┆ 3.2         ┆ 4.5          ┆ 1.5         ┆ versicolor │
+      │ 5.8          ┆ 2.7         ┆ 5.1          ┆ 1.9         ┆ virginica  │
+      │ 7.1          ┆ 3.0         ┆ 5.9          ┆ 2.1         ┆ virginica  │
+      │ 6.3          ┆ 3.3         ┆ 6.0          ┆ 2.5         ┆ virginica  │
+      └──────────────┴─────────────┴──────────────┴─────────────┴────────────┘
+
+---
+
+    Code
+      current$collect()
+    Output
+      as_polars_lf(iris)$
+        group_by(
+          "Species",
+          .maintain_order = FALSE
+        )$
+        agg(pl$all()$tail(3))$
+        explode(
+          c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"),
+          empty_as_null = FALSE
+        )$
+        select(
+          "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species"
+        )$
+        with_columns(
+          pl$col("Species")$alias("__TIDYPOLARS_TEMP_SORT__1"),
+          pl$col("Sepal.Width")$alias("__TIDYPOLARS_TEMP_SORT__2")
+        )$
+        sort(
+          "__TIDYPOLARS_TEMP_SORT__1",
+          "__TIDYPOLARS_TEMP_SORT__2",
+          descending = c(FALSE, FALSE),
+          nulls_last = TRUE
+        )$
+        drop("__TIDYPOLARS_TEMP_SORT__1", "__TIDYPOLARS_TEMP_SORT__2")
+      shape: (9, 5)
+      ┌──────────────┬─────────────┬──────────────┬─────────────┬────────────┐
+      │ Sepal.Length ┆ Sepal.Width ┆ Petal.Length ┆ Petal.Width ┆ Species    │
+      │ ---          ┆ ---         ┆ ---          ┆ ---         ┆ ---        │
+      │ f64          ┆ f64         ┆ f64          ┆ f64         ┆ cat        │
+      ╞══════════════╪═════════════╪══════════════╪═════════════╪════════════╡
+      │ 4.6          ┆ 3.2         ┆ 1.4          ┆ 0.2         ┆ setosa     │
+      │ 5.0          ┆ 3.3         ┆ 1.4          ┆ 0.2         ┆ setosa     │
+      │ 5.3          ┆ 3.7         ┆ 1.5          ┆ 0.2         ┆ setosa     │
+      │ 5.1          ┆ 2.5         ┆ 3.0          ┆ 1.1         ┆ versicolor │
+      │ 5.7          ┆ 2.8         ┆ 4.1          ┆ 1.3         ┆ versicolor │
+      │ 6.2          ┆ 2.9         ┆ 4.3          ┆ 1.3         ┆ versicolor │
+      │ 6.5          ┆ 3.0         ┆ 5.2          ┆ 2.0         ┆ virginica  │
+      │ 5.9          ┆ 3.0         ┆ 5.1          ┆ 1.8         ┆ virginica  │
+      │ 6.2          ┆ 3.4         ┆ 5.4          ┆ 2.3         ┆ virginica  │
+      └──────────────┴─────────────┴──────────────┴─────────────┴────────────┘
+
+---
+
+    Code
+      current$collect()
+    Output
+      as_polars_lf(iris)$
+        group_by(
+          "Species",
+          .maintain_order = FALSE
+        )$
+        agg(pl$all()$tail(3))$
+        explode(
+          c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"),
+          empty_as_null = FALSE
+        )$
+        select(
+          "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species"
+        )$
+        with_columns(
+          pl$col("Species")$alias("__TIDYPOLARS_TEMP_SORT__1"),
+          pl$col("Sepal.Width")$alias("__TIDYPOLARS_TEMP_SORT__2")
+        )$
+        sort(
+          "__TIDYPOLARS_TEMP_SORT__1",
+          "__TIDYPOLARS_TEMP_SORT__2",
+          descending = c(FALSE, FALSE),
+          nulls_last = TRUE
+        )$
+        drop("__TIDYPOLARS_TEMP_SORT__1", "__TIDYPOLARS_TEMP_SORT__2")
+      shape: (9, 5)
+      ┌──────────────┬─────────────┬──────────────┬─────────────┬────────────┐
+      │ Sepal.Length ┆ Sepal.Width ┆ Petal.Length ┆ Petal.Width ┆ Species    │
+      │ ---          ┆ ---         ┆ ---          ┆ ---         ┆ ---        │
+      │ f64          ┆ f64         ┆ f64          ┆ f64         ┆ cat        │
+      ╞══════════════╪═════════════╪══════════════╪═════════════╪════════════╡
+      │ 4.6          ┆ 3.2         ┆ 1.4          ┆ 0.2         ┆ setosa     │
+      │ 5.0          ┆ 3.3         ┆ 1.4          ┆ 0.2         ┆ setosa     │
+      │ 5.3          ┆ 3.7         ┆ 1.5          ┆ 0.2         ┆ setosa     │
+      │ 5.1          ┆ 2.5         ┆ 3.0          ┆ 1.1         ┆ versicolor │
+      │ 5.7          ┆ 2.8         ┆ 4.1          ┆ 1.3         ┆ versicolor │
+      │ 6.2          ┆ 2.9         ┆ 4.3          ┆ 1.3         ┆ versicolor │
+      │ 6.5          ┆ 3.0         ┆ 5.2          ┆ 2.0         ┆ virginica  │
+      │ 5.9          ┆ 3.0         ┆ 5.1          ┆ 1.8         ┆ virginica  │
+      │ 6.2          ┆ 3.4         ┆ 5.4          ┆ 2.3         ┆ virginica  │
+      └──────────────┴─────────────┴──────────────┴─────────────┴────────────┘
+
 # translated base functions: maths and rounding
 
     Code

--- a/tests/testthat/_snaps/show_query.md
+++ b/tests/testthat/_snaps/show_query.md
@@ -630,6 +630,125 @@
       as_polars_df(iris)$
         tail(3)
 
+# slice example: slice_sample()
+
+    Code
+      show_query(query)
+    Output
+      as_polars_df(iris[, c("Species", "Sepal.Width")])$
+        sample(
+          n = NULL,
+          fraction = 1,
+          with_replacement = FALSE,
+          shuffle = TRUE
+        )$
+        with_columns(
+          pl$col("Species")$alias("__TIDYPOLARS_TEMP_SORT__1"),
+          pl$col("Sepal.Width")$alias("__TIDYPOLARS_TEMP_SORT__2")
+        )$
+        sort(
+          "__TIDYPOLARS_TEMP_SORT__1",
+          "__TIDYPOLARS_TEMP_SORT__2",
+          descending = c(FALSE, FALSE),
+          nulls_last = TRUE
+        )$
+        drop("__TIDYPOLARS_TEMP_SORT__1", "__TIDYPOLARS_TEMP_SORT__2")
+
+# slice example: slice by group
+
+    Code
+      show_query(query_head)
+    Output
+      as_polars_df(iris)$
+        group_by(
+          "Species",
+          .maintain_order = FALSE
+        )$
+        agg(pl$all()$head(3))$
+        explode(
+          c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"),
+          empty_as_null = FALSE
+        )$
+        select(
+          "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species"
+        )$
+        with_columns(
+          pl$col("Species")$alias("__TIDYPOLARS_TEMP_SORT__1"),
+          pl$col("Sepal.Width")$alias("__TIDYPOLARS_TEMP_SORT__2")
+        )$
+        sort(
+          "__TIDYPOLARS_TEMP_SORT__1",
+          "__TIDYPOLARS_TEMP_SORT__2",
+          descending = c(FALSE, FALSE),
+          nulls_last = TRUE
+        )$
+        drop("__TIDYPOLARS_TEMP_SORT__1", "__TIDYPOLARS_TEMP_SORT__2")
+
+---
+
+    Code
+      show_query(query_tail)
+    Output
+      as_polars_df(iris)$
+        group_by(
+          "Species",
+          .maintain_order = FALSE
+        )$
+        agg(pl$all()$tail(3))$
+        explode(
+          c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width"),
+          empty_as_null = FALSE
+        )$
+        select(
+          "Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species"
+        )$
+        with_columns(
+          pl$col("Species")$alias("__TIDYPOLARS_TEMP_SORT__1"),
+          pl$col("Sepal.Width")$alias("__TIDYPOLARS_TEMP_SORT__2")
+        )$
+        sort(
+          "__TIDYPOLARS_TEMP_SORT__1",
+          "__TIDYPOLARS_TEMP_SORT__2",
+          descending = c(FALSE, FALSE),
+          nulls_last = TRUE
+        )$
+        drop("__TIDYPOLARS_TEMP_SORT__1", "__TIDYPOLARS_TEMP_SORT__2")
+
+---
+
+    Code
+      show_query(query_sample)
+    Output
+      as_polars_df(iris)$
+        group_by(
+          "Species",
+          .maintain_order = FALSE
+        )$
+        agg(
+          pl$struct(
+            c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
+          )$
+            sample(n = 3, fraction = NULL, with_replacement = FALSE, shuffle = TRUE)$
+            alias("__tidypolars_slice_sample_row__")
+        )$
+        explode(
+          "__tidypolars_slice_sample_row__",
+          empty_as_null = FALSE
+        )$
+        select("__tidypolars_slice_sample_row__")$
+        unnest("__tidypolars_slice_sample_row__")$
+        with_columns(
+          pl$col("Species")$alias("__TIDYPOLARS_TEMP_SORT__1"),
+          pl$col("Sepal.Width")$alias("__TIDYPOLARS_TEMP_SORT__2")
+        )$
+        sort(
+          "__TIDYPOLARS_TEMP_SORT__1",
+          "__TIDYPOLARS_TEMP_SORT__2",
+          descending = c(FALSE, FALSE),
+          nulls_last = TRUE
+        )$
+        drop("__TIDYPOLARS_TEMP_SORT__1", "__TIDYPOLARS_TEMP_SORT__2")
+
 # translated base functions: maths and rounding
 
     Code

--- a/tests/testthat/_snaps/show_query.md
+++ b/tests/testthat/_snaps/show_query.md
@@ -728,7 +728,8 @@
           pl$struct(
             c("Sepal.Length", "Sepal.Width", "Petal.Length", "Petal.Width", "Species")
           )$
-            sample(n = 3, fraction = NULL, with_replacement = FALSE, shuffle = TRUE)$
+            shuffle()$
+            head(3)$
             alias("__tidypolars_slice_sample_row__")
         )$
         explode(

--- a/tests/testthat/_snaps/slice.md
+++ b/tests/testthat/_snaps/slice.md
@@ -6,22 +6,6 @@
       Error in `slice_sample()`:
       ! You must provide either `n` or `prop`, not both.
 
----
-
-    Code
-      slice_sample(test_pl, n = 200)
-    Condition
-      Error in `slice_sample()`:
-      ! Cannot take more rows than the total number of rows when `replace = FALSE`.
-
----
-
-    Code
-      slice_sample(test_pl, prop = 1.2)
-    Condition
-      Error in `slice_sample()`:
-      ! Cannot take more rows than the total number of rows when `replace = FALSE`.
-
 # dots must be empty
 
     Code

--- a/tests/testthat/test-show_query-lazy.R
+++ b/tests/testthat/test-show_query-lazy.R
@@ -517,6 +517,46 @@ test_that("slice example: slice_head() and slice_tail()", {
   expect_equal_lazy(replay_query(query_tail), query_tail)
 })
 
+test_that("slice example: slice_sample()", {
+  skip_if(Sys.getenv('TIDYPOLARS_TEST') == "TRUE")
+  query <- iris[, c("Species", "Sepal.Width")] |>
+    as_polars_lf() |>
+    slice_sample(prop = 1) |>
+    arrange(Species, Sepal.Width)
+
+  expect_snapshot_lazy(show_query(query))
+  expect_equal_lazy(replay_query(query), query)
+})
+
+test_that("slice example: slice by group", {
+  skip_if(Sys.getenv('TIDYPOLARS_TEST') == "TRUE")
+  query_head <- iris |>
+    as_polars_lf() |>
+    group_by(Species) |>
+    slice_head(n = 3) |>
+    ungroup() |>
+    arrange(Species, Sepal.Width)
+  query_tail <- iris |>
+    as_polars_lf() |>
+    group_by(Species) |>
+    slice_tail(n = 3) |>
+    ungroup() |>
+    arrange(Species, Sepal.Width)
+  query_sample <- iris |>
+    as_polars_lf() |>
+    group_by(Species) |>
+    slice_sample(n = 3) |>
+    ungroup() |>
+    arrange(Species, Sepal.Width)
+
+  expect_snapshot_lazy(show_query(query_head))
+  expect_snapshot_lazy(show_query(query_tail))
+  expect_snapshot_lazy(show_query(query_sample))
+
+  expect_equal_lazy(replay_query(query_head), query_head)
+  expect_equal_lazy(replay_query(query_tail), query_tail)
+})
+
 # Translated functions (see the "List of supported functions" vignette). Each
 # test records a query using a family of translated functions and checks that
 # the recorded polars code reproduces the original result.

--- a/tests/testthat/test-show_query.R
+++ b/tests/testthat/test-show_query.R
@@ -513,6 +513,46 @@ test_that("slice example: slice_head() and slice_tail()", {
   expect_equal(replay_query(query_tail), query_tail)
 })
 
+test_that("slice example: slice_sample()", {
+  skip_if(Sys.getenv('TIDYPOLARS_TEST') == "TRUE")
+  query <- iris[, c("Species", "Sepal.Width")] |>
+    as_polars_df() |>
+    slice_sample(prop = 1) |>
+    arrange(Species, Sepal.Width)
+
+  expect_snapshot(show_query(query))
+  expect_equal(replay_query(query), query)
+})
+
+test_that("slice example: slice by group", {
+  skip_if(Sys.getenv('TIDYPOLARS_TEST') == "TRUE")
+  query_head <- iris |>
+    as_polars_df() |>
+    group_by(Species) |>
+    slice_head(n = 3) |>
+    ungroup() |>
+    arrange(Species, Sepal.Width)
+  query_tail <- iris |>
+    as_polars_df() |>
+    group_by(Species) |>
+    slice_tail(n = 3) |>
+    ungroup() |>
+    arrange(Species, Sepal.Width)
+  query_sample <- iris |>
+    as_polars_df() |>
+    group_by(Species) |>
+    slice_sample(n = 3) |>
+    ungroup() |>
+    arrange(Species, Sepal.Width)
+
+  expect_snapshot(show_query(query_head))
+  expect_snapshot(show_query(query_tail))
+  expect_snapshot(show_query(query_sample))
+
+  expect_equal(replay_query(query_head), query_head)
+  expect_equal(replay_query(query_tail), query_tail)
+})
+
 # Translated functions (see the "List of supported functions" vignette). Each
 # test records a query using a family of translated functions and checks that
 # the recorded polars code reproduces the original result.

--- a/tests/testthat/test-slice-lazy.R
+++ b/tests/testthat/test-slice-lazy.R
@@ -286,6 +286,38 @@ test_that("grouped slice_sample with zero rows returns zero rows", {
   )
 })
 
+test_that("grouped slice_sample works with empty data", {
+  test_df <- tibble(g = character(), x = integer())
+  test_pl <- as_polars_lf(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal_lazy(
+    test_pl |> group_by(g) |> slice_sample(n = 1),
+    test_df |> group_by(g) |> slice_sample(n = 1)
+  )
+
+  expect_equal_lazy(
+    test_pl |> slice_sample(n = 1, by = g),
+    test_df |> slice_sample(n = 1, by = g)
+  )
+})
+
+test_that("grouped slice_sample maintains group order when requested", {
+  test_df <- tibble(g = c("b", "a", "b", "c", "a"), x = 1:5)
+  test_pl <- as_polars_lf(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  out <- test_pl |>
+    group_by(g, maintain_order = TRUE) |>
+    slice_sample(n = 5) |>
+    distinct(g)
+  expected <- test_df |>
+    group_by(g) |>
+    distinct(g)
+
+  expect_equal_lazy(out, expected)
+})
+
 test_that("unsupported args throw warning", {
   test_df <- as_tibble(mtcars)
   test_pl <- as_polars_lf(test_df)

--- a/tests/testthat/test-slice-lazy.R
+++ b/tests/testthat/test-slice-lazy.R
@@ -46,6 +46,32 @@ test_that("slice_head works with grouped data", {
   expect_true(attr(slice_head(test_pl_grp, n = 2), "maintain_grp_order"))
 })
 
+test_that("grouped head and tail with zero rows return zero rows", {
+  test_df <- tibble(g = c("a", "a", "b"), x = 1:3)
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |> group_by(g) |> slice_head(n = 0),
+    test_df |> group_by(g) |> slice_head(n = 0)
+  )
+
+  expect_equal_lazy(
+    test_pl |> group_by(g) |> slice_tail(n = 0),
+    test_df |> group_by(g) |> slice_tail(n = 0)
+  )
+})
+
+test_that("grouped slice_sample with zero rows returns zero rows", {
+  test_df <- tibble(g = c("a", "a", "b"), x = 1:3)
+  test_pl <- as_polars_lf(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal_lazy(
+    test_pl |> group_by(g) |> slice_sample(n = 0),
+    test_df |> group_by(g) |> slice_sample(n = 0)
+  )
+})
+
 test_that("slice_tail works on grouped data", {
   test_df <- as_tibble(iris)
   test_pl <- as_polars_lf(test_df)
@@ -188,6 +214,38 @@ test_that("slice_sample works with grouped data", {
     test_pl |>
       slice_sample(prop = 0.1, by = Species) |>
       attr("maintain_grp_order")
+  )
+})
+
+test_that("grouped slice_sample limits n to each group size", {
+  test_df <- tibble(g = c("a", "a", "b", "b", "b"), x = 1:5)
+  test_pl <- as_polars_lf(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal_lazy(
+    test_pl |>
+      group_by(g) |>
+      slice_sample(n = 3) |>
+      ungroup() |>
+      count(g) |>
+      arrange(g),
+    test_df |>
+      group_by(g) |>
+      slice_sample(n = 3) |>
+      ungroup() |>
+      count(g) |>
+      arrange(g)
+  )
+
+  expect_equal_lazy(
+    test_pl |>
+      slice_sample(n = 3, by = g) |>
+      count(g) |>
+      arrange(g),
+    test_df |>
+      slice_sample(n = 3, by = g) |>
+      count(g) |>
+      arrange(g)
   )
 })
 

--- a/tests/testthat/test-slice-lazy.R
+++ b/tests/testthat/test-slice-lazy.R
@@ -192,26 +192,24 @@ test_that("slice_sample works with grouped data", {
   )
 
   # slice_sample by group keeps rows consistent
-  test_df <- tibble(
-    g = rep(c("a", "b"), each = 10),
-    id = 1:20,
-    x = 1:20 * 7,
-    y = paste0("row-", 1:20)
-  )
-  test_pl <- as_polars_lf(test_df)
+  test_pl <- pl$LazyFrame(g = c("a", "a", "b", "b"), x = 1:4, y = 5:8) |>
+    group_by(g)
+  foo <- slice_sample(test_pl, n = 1)
 
-  expect_equal_lazy(
-    test_pl |>
-      group_by(g) |>
-      slice_sample(n = 20) |>
-      ungroup() |>
-      arrange(g, id),
-    test_df |>
-      group_by(g) |>
-      slice_sample(n = 20) |>
-      ungroup() |>
-      arrange(g, id)
-  )
+  g1 <- filter(foo, g == "a")
+  g2 <- filter(foo, g == "b")
+
+  if (pull(g1, x) == 1) {
+    expect_equal_lazy(pull(g1, y), 5)
+  } else if (pull(g1, x) == 2) {
+    expect_equal_lazy(pull(g1, y), 6)
+  }
+
+  if (pull(g2, x) == 3) {
+    expect_equal_lazy(pull(g2, y), 7)
+  } else if (pull(g2, x) == 4) {
+    expect_equal_lazy(pull(g2, y), 8)
+  }
 })
 
 test_that("slice_sample() truncates n and prop if they are too large", {
@@ -230,7 +228,7 @@ test_that("slice_sample() truncates n and prop if they are too large", {
 })
 
 test_that("grouped slice_sample limits n to each group size", {
-  test_df <- tibble(g = c("a", "a", "b", "b", "b"), x = 1:5)
+  test_df <- tibble(g = c("a", "a", "b", "b", "b"), x = 1:5, y = 6:10)
   test_pl <- as_polars_lf(test_df)
   skip_if_not(is_polars_df(test_pl))
 

--- a/tests/testthat/test-slice-lazy.R
+++ b/tests/testthat/test-slice-lazy.R
@@ -192,40 +192,26 @@ test_that("slice_sample works with grouped data", {
   )
 
   # slice_sample by group keeps rows consistent
-  test_pl_g <- pl$LazyFrame(
-    g = c("a", "a", "b", "b", "b"),
-    x = 1:5,
-    y = 6:10
-  ) |>
-    group_by(g)
+  test_df <- tibble(
+    g = rep(c("a", "b"), each = 10),
+    id = 1:20,
+    x = 1:20 * 7,
+    y = paste0("row-", 1:20)
+  )
+  test_pl <- as_polars_lf(test_df)
 
-  foo <- slice_sample(test_pl_g, n = 1) |>
-    ungroup() |>
-    arrange(g)
-
-  g_val <- pull(foo, g)
-  x_val <- pull(foo, x)
-  y_val <- pull(foo, y)
-
-  for (i in 1:2) {
-    if (x_val[i] == 1) {
-      expect_equal_lazy(g_val[i], "a")
-      expect_equal_lazy(y_val[i], 6)
-    } else if (x_val[i] == 2) {
-      expect_equal_lazy(g_val[i], "a")
-      expect_equal_lazy(y_val[i], 7)
-    } else if (x_val[i] == 3) {
-      expect_equal_lazy(g_val[i], "b")
-      expect_equal_lazy(y_val[i], 8)
-    } else if (x_val[i] == 4) {
-      expect_equal_lazy(g_val[i], "b")
-      expect_equal_lazy(y_val[i], 9)
-    } else {
-      expect_equal_lazy(x_val[i], 5)
-      expect_equal_lazy(g_val[i], "b")
-      expect_equal_lazy(y_val[i], 10)
-    }
-  }
+  expect_equal_lazy(
+    test_pl |>
+      group_by(g) |>
+      slice_sample(n = 20) |>
+      ungroup() |>
+      arrange(g, id),
+    test_df |>
+      group_by(g) |>
+      slice_sample(n = 20) |>
+      ungroup() |>
+      arrange(g, id)
+  )
 })
 
 test_that("slice_sample() truncates n and prop if they are too large", {
@@ -316,6 +302,60 @@ test_that("grouped slice_sample maintains group order when requested", {
     distinct(g)
 
   expect_equal_lazy(out, expected)
+})
+
+test_that("slice_sample works with different group structures", {
+  test_df <- tibble(
+    g1 = c("a", "a", "a", "b"),
+    g2 = c(1L, 1L, 2L, 1L)
+  )
+  test_pl <- as_polars_lf(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  group_only_df <- test_df |> select(g1)
+  group_only_pl <- as_polars_lf(group_only_df)
+  expect_equal_lazy(
+    group_only_pl |>
+      group_by(g1) |>
+      slice_sample(n = 2) |>
+      ungroup() |>
+      arrange(g1),
+    group_only_df |>
+      group_by(g1) |>
+      slice_sample(n = 2) |>
+      ungroup() |>
+      arrange(g1)
+  )
+
+  expect_equal_lazy(
+    test_pl |>
+      group_by(g1, g2) |>
+      slice_sample(n = 1) |>
+      ungroup() |>
+      count(g1, g2) |>
+      arrange(g1, g2),
+    test_df |>
+      group_by(g1, g2) |>
+      slice_sample(n = 1) |>
+      ungroup() |>
+      count(g1, g2) |>
+      arrange(g1, g2)
+  )
+
+  expect_equal_lazy(
+    test_pl |>
+      group_by(g1, g2) |>
+      slice_sample(n = 3, replace = TRUE) |>
+      ungroup() |>
+      count(g1, g2) |>
+      arrange(g1, g2),
+    test_df |>
+      group_by(g1, g2) |>
+      slice_sample(n = 3, replace = TRUE) |>
+      ungroup() |>
+      count(g1, g2) |>
+      arrange(g1, g2)
+  )
 })
 
 test_that("unsupported args throw warning", {

--- a/tests/testthat/test-slice-lazy.R
+++ b/tests/testthat/test-slice-lazy.R
@@ -61,17 +61,6 @@ test_that("grouped head and tail with zero rows return zero rows", {
   )
 })
 
-test_that("grouped slice_sample with zero rows returns zero rows", {
-  test_df <- tibble(g = c("a", "a", "b"), x = 1:3)
-  test_pl <- as_polars_lf(test_df)
-  skip_if_not(is_polars_df(test_pl))
-
-  expect_equal_lazy(
-    test_pl |> group_by(g) |> slice_sample(n = 0),
-    test_df |> group_by(g) |> slice_sample(n = 0)
-  )
-})
-
 test_that("slice_tail works on grouped data", {
   test_df <- as_tibble(iris)
   test_pl <- as_polars_lf(test_df)
@@ -281,6 +270,17 @@ test_that("grouped slice_sample limits n to each group size", {
       slice_sample(n = 3, by = g) |>
       count(g) |>
       arrange(g)
+  )
+})
+
+test_that("grouped slice_sample with zero rows returns zero rows", {
+  test_df <- tibble(g = c("a", "a", "b"), x = 1:3)
+  test_pl <- as_polars_lf(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal_lazy(
+    test_pl |> group_by(g) |> slice_sample(n = 0),
+    test_df |> group_by(g) |> slice_sample(n = 0)
   )
 })
 

--- a/tests/testthat/test-slice-lazy.R
+++ b/tests/testthat/test-slice-lazy.R
@@ -156,8 +156,7 @@ test_that("basic slice_sample works", {
   )
 
   # slice_sample keeps rows consistent
-  test_df <- tibble(x = 1:3, y = letters[1:3], z = 4:6)
-  test_pl <- as_polars_lf(test_df)
+  test_pl <- pl$LazyFrame(x = 1:3, y = letters[1:3], z = 4:6)
   foo <- slice_sample(test_pl, n = 1)
 
   if (pull(foo, x) == 1) {
@@ -215,6 +214,42 @@ test_that("slice_sample works with grouped data", {
       slice_sample(prop = 0.1, by = Species) |>
       attr("maintain_grp_order")
   )
+
+  # slice_sample by group keeps rows consistent
+  test_pl_g <- pl$LazyFrame(
+    g = c("a", "a", "b", "b", "b"),
+    x = 1:5,
+    y = 6:10
+  ) |>
+    group_by(g)
+
+  foo <- slice_sample(test_pl_g, n = 1) |>
+    ungroup() |>
+    arrange(g)
+
+  g_val <- pull(foo, g)
+  x_val <- pull(foo, x)
+  y_val <- pull(foo, y)
+
+  for (i in 1:2) {
+    if (x_val[i] == 1) {
+      expect_equal_lazy(g_val[i], "a")
+      expect_equal_lazy(y_val[i], 6)
+    } else if (x_val[i] == 2) {
+      expect_equal_lazy(g_val[i], "a")
+      expect_equal_lazy(y_val[i], 7)
+    } else if (x_val[i] == 3) {
+      expect_equal_lazy(g_val[i], "b")
+      expect_equal_lazy(y_val[i], 8)
+    } else if (x_val[i] == 4) {
+      expect_equal_lazy(g_val[i], "b")
+      expect_equal_lazy(y_val[i], 9)
+    } else {
+      expect_equal_lazy(x_val[i], 5)
+      expect_equal_lazy(g_val[i], "b")
+      expect_equal_lazy(y_val[i], 10)
+    }
+  }
 })
 
 test_that("grouped slice_sample limits n to each group size", {

--- a/tests/testthat/test-slice-lazy.R
+++ b/tests/testthat/test-slice-lazy.R
@@ -227,7 +227,7 @@ test_that("slice_sample() truncates n and prop if they are too large", {
   )
 })
 
-test_that("grouped slice_sample limits n to each group size", {
+test_that("slice_sample() by group truncates n and prop if they are too large", {
   test_df <- tibble(g = c("a", "a", "b", "b", "b"), x = 1:5, y = 6:10)
   test_pl <- as_polars_lf(test_df)
   skip_if_not(is_polars_df(test_pl))
@@ -242,6 +242,21 @@ test_that("grouped slice_sample limits n to each group size", {
     test_df |>
       group_by(g) |>
       slice_sample(n = 3) |>
+      ungroup() |>
+      count(g) |>
+      arrange(g)
+  )
+
+  expect_equal_lazy(
+    test_pl |>
+      group_by(g) |>
+      slice_sample(prop = 1.5) |>
+      ungroup() |>
+      count(g) |>
+      arrange(g),
+    test_df |>
+      group_by(g) |>
+      slice_sample(prop = 1.5) |>
       ungroup() |>
       count(g) |>
       arrange(g)

--- a/tests/testthat/test-slice-lazy.R
+++ b/tests/testthat/test-slice-lazy.R
@@ -126,22 +126,9 @@ test_that("basic slice_sample works", {
     slice_sample(test_df, n = 200, replace = TRUE) |> nrow()
   )
 
-  # TODO? dplyr chooses to take n_rows(data) if n > n_rows(data)
-  # https://github.com/tidyverse/dplyr/issues/6185
-  expect_snapshot_lazy(
-    slice_sample(test_pl, n = 200),
-    error = TRUE
-  )
-
   expect_equal_lazy(
     slice_sample(test_pl, prop = 2, replace = TRUE) |> nrow(),
     slice_sample(test_df, prop = 2, replace = TRUE) |> nrow()
-  )
-
-  # TODO? dplyr chooses to take n_rows(data) if prop > 1
-  expect_snapshot_lazy(
-    slice_sample(test_pl, prop = 1.2),
-    error = TRUE
   )
 
   # slice_sample keeps rows consistent
@@ -239,6 +226,21 @@ test_that("slice_sample works with grouped data", {
       expect_equal_lazy(y_val[i], 10)
     }
   }
+})
+
+test_that("slice_sample() truncates n and prop if they are too large", {
+  test_df <- tibble(x = 1:5, y = 6:10)
+  test_pl <- as_polars_lf(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal_lazy(
+    test_pl |> slice_sample(n = 200) |> arrange(x, y),
+    test_df |> slice_sample(n = 200) |> arrange(x, y)
+  )
+  expect_equal_lazy(
+    test_pl |> slice_sample(prop = 1.5) |> arrange(x, y),
+    test_df |> slice_sample(prop = 1.5) |> arrange(x, y)
+  )
 })
 
 test_that("grouped slice_sample limits n to each group size", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -282,6 +282,38 @@ test_that("grouped slice_sample with zero rows returns zero rows", {
   )
 })
 
+test_that("grouped slice_sample works with empty data", {
+  test_df <- tibble(g = character(), x = integer())
+  test_pl <- as_polars_df(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal(
+    test_pl |> group_by(g) |> slice_sample(n = 1),
+    test_df |> group_by(g) |> slice_sample(n = 1)
+  )
+
+  expect_equal(
+    test_pl |> slice_sample(n = 1, by = g),
+    test_df |> slice_sample(n = 1, by = g)
+  )
+})
+
+test_that("grouped slice_sample maintains group order when requested", {
+  test_df <- tibble(g = c("b", "a", "b", "c", "a"), x = 1:5)
+  test_pl <- as_polars_df(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  out <- test_pl |>
+    group_by(g, maintain_order = TRUE) |>
+    slice_sample(n = 5) |>
+    distinct(g)
+  expected <- test_df |>
+    group_by(g) |>
+    distinct(g)
+
+  expect_equal(out, expected)
+})
+
 test_that("unsupported args throw warning", {
   test_df <- as_tibble(mtcars)
   test_pl <- as_polars_df(test_df)

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -188,40 +188,26 @@ test_that("slice_sample works with grouped data", {
   )
 
   # slice_sample by group keeps rows consistent
-  test_pl_g <- pl$DataFrame(
-    g = c("a", "a", "b", "b", "b"),
-    x = 1:5,
-    y = 6:10
-  ) |>
-    group_by(g)
+  test_df <- tibble(
+    g = rep(c("a", "b"), each = 10),
+    id = 1:20,
+    x = 1:20 * 7,
+    y = paste0("row-", 1:20)
+  )
+  test_pl <- as_polars_df(test_df)
 
-  foo <- slice_sample(test_pl_g, n = 1) |>
-    ungroup() |>
-    arrange(g)
-
-  g_val <- pull(foo, g)
-  x_val <- pull(foo, x)
-  y_val <- pull(foo, y)
-
-  for (i in 1:2) {
-    if (x_val[i] == 1) {
-      expect_equal(g_val[i], "a")
-      expect_equal(y_val[i], 6)
-    } else if (x_val[i] == 2) {
-      expect_equal(g_val[i], "a")
-      expect_equal(y_val[i], 7)
-    } else if (x_val[i] == 3) {
-      expect_equal(g_val[i], "b")
-      expect_equal(y_val[i], 8)
-    } else if (x_val[i] == 4) {
-      expect_equal(g_val[i], "b")
-      expect_equal(y_val[i], 9)
-    } else {
-      expect_equal(x_val[i], 5)
-      expect_equal(g_val[i], "b")
-      expect_equal(y_val[i], 10)
-    }
-  }
+  expect_equal(
+    test_pl |>
+      group_by(g) |>
+      slice_sample(n = 20) |>
+      ungroup() |>
+      arrange(g, id),
+    test_df |>
+      group_by(g) |>
+      slice_sample(n = 20) |>
+      ungroup() |>
+      arrange(g, id)
+  )
 })
 
 test_that("slice_sample() truncates n and prop if they are too large", {
@@ -312,6 +298,60 @@ test_that("grouped slice_sample maintains group order when requested", {
     distinct(g)
 
   expect_equal(out, expected)
+})
+
+test_that("slice_sample works with different group structures", {
+  test_df <- tibble(
+    g1 = c("a", "a", "a", "b"),
+    g2 = c(1L, 1L, 2L, 1L)
+  )
+  test_pl <- as_polars_df(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  group_only_df <- test_df |> select(g1)
+  group_only_pl <- as_polars_df(group_only_df)
+  expect_equal(
+    group_only_pl |>
+      group_by(g1) |>
+      slice_sample(n = 2) |>
+      ungroup() |>
+      arrange(g1),
+    group_only_df |>
+      group_by(g1) |>
+      slice_sample(n = 2) |>
+      ungroup() |>
+      arrange(g1)
+  )
+
+  expect_equal(
+    test_pl |>
+      group_by(g1, g2) |>
+      slice_sample(n = 1) |>
+      ungroup() |>
+      count(g1, g2) |>
+      arrange(g1, g2),
+    test_df |>
+      group_by(g1, g2) |>
+      slice_sample(n = 1) |>
+      ungroup() |>
+      count(g1, g2) |>
+      arrange(g1, g2)
+  )
+
+  expect_equal(
+    test_pl |>
+      group_by(g1, g2) |>
+      slice_sample(n = 3, replace = TRUE) |>
+      ungroup() |>
+      count(g1, g2) |>
+      arrange(g1, g2),
+    test_df |>
+      group_by(g1, g2) |>
+      slice_sample(n = 3, replace = TRUE) |>
+      ungroup() |>
+      count(g1, g2) |>
+      arrange(g1, g2)
+  )
 })
 
 test_that("unsupported args throw warning", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -152,8 +152,7 @@ test_that("basic slice_sample works", {
   )
 
   # slice_sample keeps rows consistent
-  test_df <- tibble(x = 1:3, y = letters[1:3], z = 4:6)
-  test_pl <- as_polars_df(test_df)
+  test_pl <- pl$DataFrame(x = 1:3, y = letters[1:3], z = 4:6)
   foo <- slice_sample(test_pl, n = 1)
 
   if (pull(foo, x) == 1) {
@@ -211,6 +210,42 @@ test_that("slice_sample works with grouped data", {
       slice_sample(prop = 0.1, by = Species) |>
       attr("maintain_grp_order")
   )
+
+  # slice_sample by group keeps rows consistent
+  test_pl_g <- pl$DataFrame(
+    g = c("a", "a", "b", "b", "b"),
+    x = 1:5,
+    y = 6:10
+  ) |>
+    group_by(g)
+
+  foo <- slice_sample(test_pl_g, n = 1) |>
+    ungroup() |>
+    arrange(g)
+
+  g_val <- pull(foo, g)
+  x_val <- pull(foo, x)
+  y_val <- pull(foo, y)
+
+  for (i in 1:2) {
+    if (x_val[i] == 1) {
+      expect_equal(g_val[i], "a")
+      expect_equal(y_val[i], 6)
+    } else if (x_val[i] == 2) {
+      expect_equal(g_val[i], "a")
+      expect_equal(y_val[i], 7)
+    } else if (x_val[i] == 3) {
+      expect_equal(g_val[i], "b")
+      expect_equal(y_val[i], 8)
+    } else if (x_val[i] == 4) {
+      expect_equal(g_val[i], "b")
+      expect_equal(y_val[i], 9)
+    } else {
+      expect_equal(x_val[i], 5)
+      expect_equal(g_val[i], "b")
+      expect_equal(y_val[i], 10)
+    }
+  }
 })
 
 test_that("grouped slice_sample limits n to each group size", {

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -57,17 +57,6 @@ test_that("grouped head and tail with zero rows return zero rows", {
   )
 })
 
-test_that("grouped slice_sample with zero rows returns zero rows", {
-  test_df <- tibble(g = c("a", "a", "b"), x = 1:3)
-  test_pl <- as_polars_df(test_df)
-  skip_if_not(is_polars_df(test_pl))
-
-  expect_equal(
-    test_pl |> group_by(g) |> slice_sample(n = 0),
-    test_df |> group_by(g) |> slice_sample(n = 0)
-  )
-})
-
 test_that("slice_tail works on grouped data", {
   test_df <- as_tibble(iris)
   test_pl <- as_polars_df(test_df)
@@ -277,6 +266,17 @@ test_that("grouped slice_sample limits n to each group size", {
       slice_sample(n = 3, by = g) |>
       count(g) |>
       arrange(g)
+  )
+})
+
+test_that("grouped slice_sample with zero rows returns zero rows", {
+  test_df <- tibble(g = c("a", "a", "b"), x = 1:3)
+  test_pl <- as_polars_df(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal(
+    test_pl |> group_by(g) |> slice_sample(n = 0),
+    test_df |> group_by(g) |> slice_sample(n = 0)
   )
 })
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -223,7 +223,7 @@ test_that("slice_sample() truncates n and prop if they are too large", {
   )
 })
 
-test_that("grouped slice_sample limits n to each group size", {
+test_that("slice_sample() by group truncates n and prop if they are too large", {
   test_df <- tibble(g = c("a", "a", "b", "b", "b"), x = 1:5, y = 6:10)
   test_pl <- as_polars_df(test_df)
   skip_if_not(is_polars_df(test_pl))
@@ -238,6 +238,21 @@ test_that("grouped slice_sample limits n to each group size", {
     test_df |>
       group_by(g) |>
       slice_sample(n = 3) |>
+      ungroup() |>
+      count(g) |>
+      arrange(g)
+  )
+
+  expect_equal(
+    test_pl |>
+      group_by(g) |>
+      slice_sample(prop = 1.5) |>
+      ungroup() |>
+      count(g) |>
+      arrange(g),
+    test_df |>
+      group_by(g) |>
+      slice_sample(prop = 1.5) |>
       ungroup() |>
       count(g) |>
       arrange(g)

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -188,26 +188,24 @@ test_that("slice_sample works with grouped data", {
   )
 
   # slice_sample by group keeps rows consistent
-  test_df <- tibble(
-    g = rep(c("a", "b"), each = 10),
-    id = 1:20,
-    x = 1:20 * 7,
-    y = paste0("row-", 1:20)
-  )
-  test_pl <- as_polars_df(test_df)
+  test_pl <- pl$DataFrame(g = c("a", "a", "b", "b"), x = 1:4, y = 5:8) |>
+    group_by(g)
+  foo <- slice_sample(test_pl, n = 1)
 
-  expect_equal(
-    test_pl |>
-      group_by(g) |>
-      slice_sample(n = 20) |>
-      ungroup() |>
-      arrange(g, id),
-    test_df |>
-      group_by(g) |>
-      slice_sample(n = 20) |>
-      ungroup() |>
-      arrange(g, id)
-  )
+  g1 <- filter(foo, g == "a")
+  g2 <- filter(foo, g == "b")
+
+  if (pull(g1, x) == 1) {
+    expect_equal(pull(g1, y), 5)
+  } else if (pull(g1, x) == 2) {
+    expect_equal(pull(g1, y), 6)
+  }
+
+  if (pull(g2, x) == 3) {
+    expect_equal(pull(g2, y), 7)
+  } else if (pull(g2, x) == 4) {
+    expect_equal(pull(g2, y), 8)
+  }
 })
 
 test_that("slice_sample() truncates n and prop if they are too large", {
@@ -226,7 +224,7 @@ test_that("slice_sample() truncates n and prop if they are too large", {
 })
 
 test_that("grouped slice_sample limits n to each group size", {
-  test_df <- tibble(g = c("a", "a", "b", "b", "b"), x = 1:5)
+  test_df <- tibble(g = c("a", "a", "b", "b", "b"), x = 1:5, y = 6:10)
   test_pl <- as_polars_df(test_df)
   skip_if_not(is_polars_df(test_pl))
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -42,6 +42,32 @@ test_that("slice_head works with grouped data", {
   expect_true(attr(slice_head(test_pl_grp, n = 2), "maintain_grp_order"))
 })
 
+test_that("grouped head and tail with zero rows return zero rows", {
+  test_df <- tibble(g = c("a", "a", "b"), x = 1:3)
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |> group_by(g) |> slice_head(n = 0),
+    test_df |> group_by(g) |> slice_head(n = 0)
+  )
+
+  expect_equal(
+    test_pl |> group_by(g) |> slice_tail(n = 0),
+    test_df |> group_by(g) |> slice_tail(n = 0)
+  )
+})
+
+test_that("grouped slice_sample with zero rows returns zero rows", {
+  test_df <- tibble(g = c("a", "a", "b"), x = 1:3)
+  test_pl <- as_polars_df(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal(
+    test_pl |> group_by(g) |> slice_sample(n = 0),
+    test_df |> group_by(g) |> slice_sample(n = 0)
+  )
+})
+
 test_that("slice_tail works on grouped data", {
   test_df <- as_tibble(iris)
   test_pl <- as_polars_df(test_df)
@@ -184,6 +210,38 @@ test_that("slice_sample works with grouped data", {
     test_pl |>
       slice_sample(prop = 0.1, by = Species) |>
       attr("maintain_grp_order")
+  )
+})
+
+test_that("grouped slice_sample limits n to each group size", {
+  test_df <- tibble(g = c("a", "a", "b", "b", "b"), x = 1:5)
+  test_pl <- as_polars_df(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal(
+    test_pl |>
+      group_by(g) |>
+      slice_sample(n = 3) |>
+      ungroup() |>
+      count(g) |>
+      arrange(g),
+    test_df |>
+      group_by(g) |>
+      slice_sample(n = 3) |>
+      ungroup() |>
+      count(g) |>
+      arrange(g)
+  )
+
+  expect_equal(
+    test_pl |>
+      slice_sample(n = 3, by = g) |>
+      count(g) |>
+      arrange(g),
+    test_df |>
+      slice_sample(n = 3, by = g) |>
+      count(g) |>
+      arrange(g)
   )
 })
 

--- a/tests/testthat/test-slice.R
+++ b/tests/testthat/test-slice.R
@@ -122,22 +122,9 @@ test_that("basic slice_sample works", {
     slice_sample(test_df, n = 200, replace = TRUE) |> nrow()
   )
 
-  # TODO? dplyr chooses to take n_rows(data) if n > n_rows(data)
-  # https://github.com/tidyverse/dplyr/issues/6185
-  expect_snapshot(
-    slice_sample(test_pl, n = 200),
-    error = TRUE
-  )
-
   expect_equal(
     slice_sample(test_pl, prop = 2, replace = TRUE) |> nrow(),
     slice_sample(test_df, prop = 2, replace = TRUE) |> nrow()
-  )
-
-  # TODO? dplyr chooses to take n_rows(data) if prop > 1
-  expect_snapshot(
-    slice_sample(test_pl, prop = 1.2),
-    error = TRUE
   )
 
   # slice_sample keeps rows consistent
@@ -235,6 +222,21 @@ test_that("slice_sample works with grouped data", {
       expect_equal(y_val[i], 10)
     }
   }
+})
+
+test_that("slice_sample() truncates n and prop if they are too large", {
+  test_df <- tibble(x = 1:5, y = 6:10)
+  test_pl <- as_polars_df(test_df)
+  skip_if_not(is_polars_df(test_pl))
+
+  expect_equal(
+    test_pl |> slice_sample(n = 200) |> arrange(x, y),
+    test_df |> slice_sample(n = 200) |> arrange(x, y)
+  )
+  expect_equal(
+    test_pl |> slice_sample(prop = 1.5) |> arrange(x, y),
+    test_df |> slice_sample(prop = 1.5) |> arrange(x, y)
+  )
 })
 
 test_that("grouped slice_sample limits n to each group size", {


### PR DESCRIPTION
Fix grouped `slice_head()` and `slice_tail()` with `n = 0` by preserving empty groups as zero rows, and fix grouped `slice_sample()` when `n` exceeds a group size by sampling at most the available rows per group.

``` r
library(dplyr)
library(tidypolars)

test_df <- tibble(
  g = c("a", "a", "b", "b", "b"),
  x = 1:5
)
test_pl <- as_polars_df(test_df)

slice_head(test_df |> group_by(g), n = 0)
#> # A tibble: 0 × 2
#> # Groups:   g [0]
#> # ℹ 2 variables: g <chr>, x <int>
slice_head(test_pl |> group_by(g), n = 0)
#> shape: (2, 2)
#> ┌─────┬──────┐
#> │ g   ┆ x    │
#> │ --- ┆ ---  │
#> │ str ┆ i32  │
#> ╞═════╪══════╡
#> │ a   ┆ null │
#> │ b   ┆ null │
#> └─────┴──────┘
#> Groups [2]: g
#> Maintain order: FALSE

slice_sample(test_df |> group_by(g), n = 3)
#> # A tibble: 5 × 2
#> # Groups:   g [2]
#>   g         x
#>   <chr> <int>
#> 1 a         1
#> 2 a         2
#> 3 b         4
#> 4 b         5
#> 5 b         3
slice_sample(test_pl |> group_by(g), n = 3)
#> Error:
#> ! Evaluation failed in `$agg()`.
#> Caused by error:
#> ! Evaluation failed in `$collect()`.
#> Caused by error:
#> ! lengths don't match: cannot take a larger sample than the total population when `with_replacement=false`
```