### PR TITLE
perf: Do not automatically sort the output of `pivot_longer()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
 * Added support for `anyDuplicated()`, and for the `incomparables` and `fromLast`
   arguments of `duplicated()` (#375, @Yousa-Mirage).
 
+* Improved the performance of `pivot_longer()` by no longer sorting its
+  output (#395, @Yousa-Mirage).
+
 ## Bug fixes
 
 * Multiple fixes to improve compatibility with `stringr` for the following functions:

--- a/R/pivot_longer.R
+++ b/R/pivot_longer.R
@@ -59,14 +59,12 @@ pivot_longer.polars_data_frame <- function(
   data_names <- names(data)
   on <- tidyselect_named_arg(data, rlang::enquo(cols))
   index <- data_names[!data_names %in% on]
-
-  temp_row_id <- "__tidypolars_pivot_longer_row_id__"
-  out <- data$with_row_index(name = temp_row_id)$unpivot(
-    index = c(index, temp_row_id),
+  out <- data$unpivot(
+    index = index,
     on = on,
     variable_name = names_to,
     value_name = values_to
-  )$sort(temp_row_id, maintain_order = TRUE)$drop(temp_row_id)
+  )
 
   if (!is.null(names_prefix)) {
     out <- out$with_columns(

--- a/R/pivot_longer.R
+++ b/R/pivot_longer.R
@@ -66,7 +66,7 @@ pivot_longer.polars_data_frame <- function(
     on = on,
     variable_name = names_to,
     value_name = values_to
-  )$sort(temp_row_id)$drop(temp_row_id)
+  )$sort(temp_row_id, maintain_order = TRUE)$drop(temp_row_id)
 
   if (!is.null(names_prefix)) {
     out <- out$with_columns(

--- a/R/pivot_longer.R
+++ b/R/pivot_longer.R
@@ -59,12 +59,14 @@ pivot_longer.polars_data_frame <- function(
   data_names <- names(data)
   on <- tidyselect_named_arg(data, rlang::enquo(cols))
   index <- data_names[!data_names %in% on]
-  out <- data$unpivot(
-    index = index,
+
+  temp_row_id <- "__tidypolars_pivot_longer_row_id__"
+  out <- data$with_row_index(name = temp_row_id)$unpivot(
+    index = c(index, temp_row_id),
     on = on,
     variable_name = names_to,
     value_name = values_to
-  )$sort(index)
+  )$sort(temp_row_id)$drop(temp_row_id)
 
   if (!is.null(names_prefix)) {
     out <- out$with_columns(

--- a/tests/testthat/_snaps/show_query-lazy.md
+++ b/tests/testthat/_snaps/show_query-lazy.md
@@ -867,8 +867,9 @@
       current$collect()
     Output
       as_polars_lf(tidyr::relig_income)$
+        with_row_index(name = "__tidypolars_pivot_longer_row_id__")$
         unpivot(
-          index = "religion",
+          index = c("religion", "__tidypolars_pivot_longer_row_id__"),
           on = c(
             "<$10k", "$10-20k", "$20-30k", "$30-40k", "$40-50k", "$50-75k",
             "$75-100k", "$100-150k", ">150k", "Don't know/refused"
@@ -876,7 +877,8 @@
           variable_name = "income",
           value_name = "count"
         )$
-        sort("religion")
+        sort("__tidypolars_pivot_longer_row_id__")$
+        drop("__tidypolars_pivot_longer_row_id__")
       shape: (180, 3)
       ┌──────────────┬────────────────────┬───────┐
       │ religion     ┆ income             ┆ count │

--- a/tests/testthat/_snaps/show_query-lazy.md
+++ b/tests/testthat/_snaps/show_query-lazy.md
@@ -867,39 +867,33 @@
       current$collect()
     Output
       as_polars_lf(tidyr::relig_income)$
-        with_row_index(name = "__tidypolars_pivot_longer_row_id__")$
         unpivot(
-          index = c("religion", "__tidypolars_pivot_longer_row_id__"),
+          index = "religion",
           on = c(
             "<$10k", "$10-20k", "$20-30k", "$30-40k", "$40-50k", "$50-75k",
             "$75-100k", "$100-150k", ">150k", "Don't know/refused"
           ),
           variable_name = "income",
           value_name = "count"
-        )$
-        sort(
-          "__tidypolars_pivot_longer_row_id__",
-          maintain_order = TRUE
-        )$
-        drop("__tidypolars_pivot_longer_row_id__")
+        )
       shape: (180, 3)
-      ┌──────────────┬────────────────────┬───────┐
-      │ religion     ┆ income             ┆ count │
-      │ ---          ┆ ---                ┆ ---   │
-      │ str          ┆ str                ┆ f64   │
-      ╞══════════════╪════════════════════╪═══════╡
-      │ Agnostic     ┆ <$10k              ┆ 27.0  │
-      │ Agnostic     ┆ $10-20k            ┆ 34.0  │
-      │ Agnostic     ┆ $20-30k            ┆ 60.0  │
-      │ Agnostic     ┆ $30-40k            ┆ 81.0  │
-      │ Agnostic     ┆ $40-50k            ┆ 76.0  │
-      │ …            ┆ …                  ┆ …     │
-      │ Unaffiliated ┆ $50-75k            ┆ 528.0 │
-      │ Unaffiliated ┆ $75-100k           ┆ 407.0 │
-      │ Unaffiliated ┆ $100-150k          ┆ 321.0 │
-      │ Unaffiliated ┆ >150k              ┆ 258.0 │
-      │ Unaffiliated ┆ Don't know/refused ┆ 597.0 │
-      └──────────────┴────────────────────┴───────┘
+      ┌───────────────────────┬────────────────────┬───────┐
+      │ religion              ┆ income             ┆ count │
+      │ ---                   ┆ ---                ┆ ---   │
+      │ str                   ┆ str                ┆ f64   │
+      ╞═══════════════════════╪════════════════════╪═══════╡
+      │ Agnostic              ┆ <$10k              ┆ 27.0  │
+      │ Atheist               ┆ <$10k              ┆ 12.0  │
+      │ Buddhist              ┆ <$10k              ┆ 27.0  │
+      │ Catholic              ┆ <$10k              ┆ 418.0 │
+      │ Don’t know/refused    ┆ <$10k              ┆ 15.0  │
+      │ …                     ┆ …                  ┆ …     │
+      │ Orthodox              ┆ Don't know/refused ┆ 73.0  │
+      │ Other Christian       ┆ Don't know/refused ┆ 18.0  │
+      │ Other Faiths          ┆ Don't know/refused ┆ 71.0  │
+      │ Other World Religions ┆ Don't know/refused ┆ 8.0   │
+      │ Unaffiliated          ┆ Don't know/refused ┆ 597.0 │
+      └───────────────────────┴────────────────────┴───────┘
 
 # separate() example: split on a dot
 

--- a/tests/testthat/_snaps/show_query-lazy.md
+++ b/tests/testthat/_snaps/show_query-lazy.md
@@ -877,7 +877,10 @@
           variable_name = "income",
           value_name = "count"
         )$
-        sort("__tidypolars_pivot_longer_row_id__")$
+        sort(
+          "__tidypolars_pivot_longer_row_id__",
+          maintain_order = TRUE
+        )$
         drop("__tidypolars_pivot_longer_row_id__")
       shape: (180, 3)
       ┌──────────────┬────────────────────┬───────┐

--- a/tests/testthat/_snaps/show_query.md
+++ b/tests/testthat/_snaps/show_query.md
@@ -537,21 +537,15 @@
       show_query(query)
     Output
       as_polars_df(tidyr::relig_income)$
-        with_row_index(name = "__tidypolars_pivot_longer_row_id__")$
         unpivot(
-          index = c("religion", "__tidypolars_pivot_longer_row_id__"),
+          index = "religion",
           on = c(
             "<$10k", "$10-20k", "$20-30k", "$30-40k", "$40-50k", "$50-75k",
             "$75-100k", "$100-150k", ">150k", "Don't know/refused"
           ),
           variable_name = "income",
           value_name = "count"
-        )$
-        sort(
-          "__tidypolars_pivot_longer_row_id__",
-          maintain_order = TRUE
-        )$
-        drop("__tidypolars_pivot_longer_row_id__")
+        )
 
 # separate() example: split on a dot
 

--- a/tests/testthat/_snaps/show_query.md
+++ b/tests/testthat/_snaps/show_query.md
@@ -547,7 +547,10 @@
           variable_name = "income",
           value_name = "count"
         )$
-        sort("__tidypolars_pivot_longer_row_id__")$
+        sort(
+          "__tidypolars_pivot_longer_row_id__",
+          maintain_order = TRUE
+        )$
         drop("__tidypolars_pivot_longer_row_id__")
 
 # separate() example: split on a dot

--- a/tests/testthat/_snaps/show_query.md
+++ b/tests/testthat/_snaps/show_query.md
@@ -537,8 +537,9 @@
       show_query(query)
     Output
       as_polars_df(tidyr::relig_income)$
+        with_row_index(name = "__tidypolars_pivot_longer_row_id__")$
         unpivot(
-          index = "religion",
+          index = c("religion", "__tidypolars_pivot_longer_row_id__"),
           on = c(
             "<$10k", "$10-20k", "$20-30k", "$30-40k", "$40-50k", "$50-75k",
             "$75-100k", "$100-150k", ">150k", "Don't know/refused"
@@ -546,7 +547,8 @@
           variable_name = "income",
           value_name = "count"
         )$
-        sort("religion")
+        sort("__tidypolars_pivot_longer_row_id__")$
+        drop("__tidypolars_pivot_longer_row_id__")
 
 # separate() example: split on a dot
 

--- a/tests/testthat/test-pivot_longer-lazy.R
+++ b/tests/testthat/test-pivot_longer-lazy.R
@@ -12,8 +12,11 @@ test_that("basic behavior works", {
 
   expect_equal_lazy(
     test_pl |>
-      pivot_longer(!religion, names_to = "income", values_to = "count"),
-    test_df |> pivot_longer(!religion, names_to = "income", values_to = "count")
+      pivot_longer(!religion, names_to = "income", values_to = "count") |>
+      arrange(religion, income, count),
+    test_df |>
+      pivot_longer(!religion, names_to = "income", values_to = "count") |>
+      arrange(religion, income, count)
   )
 })
 
@@ -51,51 +54,6 @@ test_that("argument names_prefix works", {
         names_prefix = c("wk", "foo")
       ),
     error = TRUE
-  )
-})
-
-test_that("row order is preserved", {
-  test_df <- data.frame(id = c(2L, 1L), a = c("a2", "a1"), b = c("b2", "b1"))
-  test_pl <- as_polars_lf(test_df)
-
-  expect_equal_lazy(
-    test_pl |> pivot_longer(c(a, b)),
-    test_df |> pivot_longer(c(a, b))
-  )
-})
-
-test_that("no index column: output is in row-major order", {
-  test_df <- data.frame(a = c("a1", "a2"), b = c("b1", "b2"))
-  test_pl <- as_polars_lf(test_df)
-
-  expect_equal_lazy(
-    test_pl |> pivot_longer(c(a, b)),
-    test_df |> pivot_longer(c(a, b))
-  )
-})
-
-test_that("repeated index values keep the original row order", {
-  test_df <- data.frame(id = c(1L, 1L, 2L), a = 1:3, b = 4:6)
-  test_pl <- as_polars_lf(test_df)
-
-  expect_equal_lazy(
-    test_pl |> pivot_longer(c(a, b)),
-    test_df |> pivot_longer(c(a, b))
-  )
-})
-
-test_that("selected columns keep their tidy-select order", {
-  test_df <- data.frame(
-    id = c(2L, 1L),
-    a = c("a2", "a1"),
-    b = c("b2", "b1"),
-    c = c("c2", "c1")
-  )
-  test_pl <- as_polars_lf(test_df)
-
-  expect_equal_lazy(
-    test_pl |> pivot_longer(c(c, a, b)),
-    test_df |> pivot_longer(c(c, a, b))
   )
 })
 

--- a/tests/testthat/test-pivot_longer-lazy.R
+++ b/tests/testthat/test-pivot_longer-lazy.R
@@ -88,6 +88,21 @@ test_that("repeated index values keep the original row order", {
   )
 })
 
+test_that("selected columns keep their tidy-select order", {
+  test_df <- data.frame(
+    id = c(2L, 1L),
+    a = c("a2", "a1"),
+    b = c("b2", "b1"),
+    c = c("c2", "c1")
+  )
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |> pivot_longer(c(c, a, b)),
+    test_df |> pivot_longer(c(c, a, b))
+  )
+})
+
 test_that("unsupported args throw warning", {
   test_df <- as.data.frame(tidyr::billboard)
   test_pl <- as_polars_lf(test_df)

--- a/tests/testthat/test-pivot_longer-lazy.R
+++ b/tests/testthat/test-pivot_longer-lazy.R
@@ -55,8 +55,6 @@ test_that("argument names_prefix works", {
 })
 
 test_that("row order is preserved", {
-  # index values in non-increasing order: sorting by the index columns would
-  # reorder the rows, the output must keep the original row order
   test_df <- data.frame(id = c(2L, 1L), a = c("a2", "a1"), b = c("b2", "b1"))
   test_pl <- as_polars_lf(test_df)
 
@@ -67,8 +65,6 @@ test_that("row order is preserved", {
 })
 
 test_that("no index column: output is in row-major order", {
-  # all columns are pivoted, the output must be a, b, a, b (row-major), not
-  # a, a, b, b (column-major)
   test_df <- data.frame(a = c("a1", "a2"), b = c("b1", "b2"))
   test_pl <- as_polars_lf(test_df)
 

--- a/tests/testthat/test-pivot_longer-lazy.R
+++ b/tests/testthat/test-pivot_longer-lazy.R
@@ -54,6 +54,40 @@ test_that("argument names_prefix works", {
   )
 })
 
+test_that("row order is preserved", {
+  # index values in non-increasing order: sorting by the index columns would
+  # reorder the rows, the output must keep the original row order
+  test_df <- data.frame(id = c(2L, 1L), a = c("a2", "a1"), b = c("b2", "b1"))
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |> pivot_longer(c(a, b)),
+    test_df |> pivot_longer(c(a, b))
+  )
+})
+
+test_that("no index column: output is in row-major order", {
+  # all columns are pivoted, the output must be a, b, a, b (row-major), not
+  # a, a, b, b (column-major)
+  test_df <- data.frame(a = c("a1", "a2"), b = c("b1", "b2"))
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |> pivot_longer(c(a, b)),
+    test_df |> pivot_longer(c(a, b))
+  )
+})
+
+test_that("repeated index values keep the original row order", {
+  test_df <- data.frame(id = c(1L, 1L, 2L), a = 1:3, b = 4:6)
+  test_pl <- as_polars_lf(test_df)
+
+  expect_equal_lazy(
+    test_pl |> pivot_longer(c(a, b)),
+    test_df |> pivot_longer(c(a, b))
+  )
+})
+
 test_that("unsupported args throw warning", {
   test_df <- as.data.frame(tidyr::billboard)
   test_pl <- as_polars_lf(test_df)

--- a/tests/testthat/test-pivot_longer.R
+++ b/tests/testthat/test-pivot_longer.R
@@ -51,8 +51,6 @@ test_that("argument names_prefix works", {
 })
 
 test_that("row order is preserved", {
-  # index values in non-increasing order: sorting by the index columns would
-  # reorder the rows, the output must keep the original row order
   test_df <- data.frame(id = c(2L, 1L), a = c("a2", "a1"), b = c("b2", "b1"))
   test_pl <- as_polars_df(test_df)
 
@@ -63,8 +61,6 @@ test_that("row order is preserved", {
 })
 
 test_that("no index column: output is in row-major order", {
-  # all columns are pivoted, the output must be a, b, a, b (row-major), not
-  # a, a, b, b (column-major)
   test_df <- data.frame(a = c("a1", "a2"), b = c("b1", "b2"))
   test_pl <- as_polars_df(test_df)
 

--- a/tests/testthat/test-pivot_longer.R
+++ b/tests/testthat/test-pivot_longer.R
@@ -8,8 +8,11 @@ test_that("basic behavior works", {
 
   expect_equal(
     test_pl |>
-      pivot_longer(!religion, names_to = "income", values_to = "count"),
-    test_df |> pivot_longer(!religion, names_to = "income", values_to = "count")
+      pivot_longer(!religion, names_to = "income", values_to = "count") |>
+      arrange(religion, income, count),
+    test_df |>
+      pivot_longer(!religion, names_to = "income", values_to = "count") |>
+      arrange(religion, income, count)
   )
 })
 
@@ -47,51 +50,6 @@ test_that("argument names_prefix works", {
         names_prefix = c("wk", "foo")
       ),
     error = TRUE
-  )
-})
-
-test_that("row order is preserved", {
-  test_df <- data.frame(id = c(2L, 1L), a = c("a2", "a1"), b = c("b2", "b1"))
-  test_pl <- as_polars_df(test_df)
-
-  expect_equal(
-    test_pl |> pivot_longer(c(a, b)),
-    test_df |> pivot_longer(c(a, b))
-  )
-})
-
-test_that("no index column: output is in row-major order", {
-  test_df <- data.frame(a = c("a1", "a2"), b = c("b1", "b2"))
-  test_pl <- as_polars_df(test_df)
-
-  expect_equal(
-    test_pl |> pivot_longer(c(a, b)),
-    test_df |> pivot_longer(c(a, b))
-  )
-})
-
-test_that("repeated index values keep the original row order", {
-  test_df <- data.frame(id = c(1L, 1L, 2L), a = 1:3, b = 4:6)
-  test_pl <- as_polars_df(test_df)
-
-  expect_equal(
-    test_pl |> pivot_longer(c(a, b)),
-    test_df |> pivot_longer(c(a, b))
-  )
-})
-
-test_that("selected columns keep their tidy-select order", {
-  test_df <- data.frame(
-    id = c(2L, 1L),
-    a = c("a2", "a1"),
-    b = c("b2", "b1"),
-    c = c("c2", "c1")
-  )
-  test_pl <- as_polars_df(test_df)
-
-  expect_equal(
-    test_pl |> pivot_longer(c(c, a, b)),
-    test_df |> pivot_longer(c(c, a, b))
   )
 })
 

--- a/tests/testthat/test-pivot_longer.R
+++ b/tests/testthat/test-pivot_longer.R
@@ -50,6 +50,40 @@ test_that("argument names_prefix works", {
   )
 })
 
+test_that("row order is preserved", {
+  # index values in non-increasing order: sorting by the index columns would
+  # reorder the rows, the output must keep the original row order
+  test_df <- data.frame(id = c(2L, 1L), a = c("a2", "a1"), b = c("b2", "b1"))
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |> pivot_longer(c(a, b)),
+    test_df |> pivot_longer(c(a, b))
+  )
+})
+
+test_that("no index column: output is in row-major order", {
+  # all columns are pivoted, the output must be a, b, a, b (row-major), not
+  # a, a, b, b (column-major)
+  test_df <- data.frame(a = c("a1", "a2"), b = c("b1", "b2"))
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |> pivot_longer(c(a, b)),
+    test_df |> pivot_longer(c(a, b))
+  )
+})
+
+test_that("repeated index values keep the original row order", {
+  test_df <- data.frame(id = c(1L, 1L, 2L), a = 1:3, b = 4:6)
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |> pivot_longer(c(a, b)),
+    test_df |> pivot_longer(c(a, b))
+  )
+})
+
 test_that("unsupported args throw warning", {
   test_df <- as.data.frame(tidyr::billboard)
   test_pl <- as_polars_df(test_df)

--- a/tests/testthat/test-pivot_longer.R
+++ b/tests/testthat/test-pivot_longer.R
@@ -84,6 +84,21 @@ test_that("repeated index values keep the original row order", {
   )
 })
 
+test_that("selected columns keep their tidy-select order", {
+  test_df <- data.frame(
+    id = c(2L, 1L),
+    a = c("a2", "a1"),
+    b = c("b2", "b1"),
+    c = c("c2", "c1")
+  )
+  test_pl <- as_polars_df(test_df)
+
+  expect_equal(
+    test_pl |> pivot_longer(c(c, a, b)),
+    test_df |> pivot_longer(c(c, a, b))
+  )
+})
+
 test_that("unsupported args throw warning", {
   test_df <- as.data.frame(tidyr::billboard)
   test_pl <- as_polars_df(test_df)


### PR DESCRIPTION
Currently, the row order of the result of `pivot_longer()` is not guaranteed to be consistent with the result of `tidyr`:

``` r
library(dplyr)
library(tidyr)
library(tidypolars)

test_df <- tibble(
  id = c(2L, 1L),
  a = c("a2", "a1"),
  b = c("b2", "b1")
)
test_pl <- as_polars_df(test_df)

test_df |> pivot_longer(c(a, b), names_to = "name", values_to = "value")
#> # A tibble: 4 × 3
#>      id name  value
#>   <int> <chr> <chr>
#> 1     2 a     a2   
#> 2     2 b     b2   
#> 3     1 a     a1   
#> 4     1 b     b1
test_pl |> pivot_longer(c(a, b), names_to = "name", values_to = "value")
#> shape: (4, 3)
#> ┌─────┬──────┬───────┐
#> │ id  ┆ name ┆ value │
#> │ --- ┆ ---  ┆ ---   │
#> │ i32 ┆ str  ┆ str   │
#> ╞═════╪══════╪═══════╡
#> │ 1   ┆ a    ┆ a1    │
#> │ 1   ┆ b    ┆ b1    │
#> │ 2   ┆ a    ┆ a2    │
#> │ 2   ┆ b    ┆ b2    │
#> └─────┴──────┴───────┘
```

This PR added a temporary helper column to help keep the row order intact.