### PR TITLE
feat: Support missing conditions and `missing` argument in `if_else()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,12 +24,12 @@
 
 * Allow `quote_style = "never"` in `sink_csv()` (#393, @Yousa-Mirage).
 
-* Added support for the `missing` argument in `if_else()`.
+* Added support for the `missing` argument in `if_else()` (#399, @Yousa-Mirage).
 
 ## Bug fixes
 
 * `ifelse()` and `if_else()` now return missing values when their condition is
-  missing, consistently with base R and dplyr.
+  missing, consistently with base R and dplyr (#399, @Yousa-Mirage).
 
 * Fix the function name in deprecation warnings from `sink_csv()` (#393, @Yousa-Mirage).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,12 @@
 
 * Allow `quote_style = "never"` in `sink_csv()` (#393, @Yousa-Mirage).
 
+* Added support for the `missing` argument in `if_else()`.
+
 ## Bug fixes
+
+* `ifelse()` and `if_else()` now return missing values when their condition is
+  missing, consistently with base R and dplyr.
 
 * Fix the function name in deprecation warnings from `sink_csv()` (#393, @Yousa-Mirage).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
 ## Bug fixes
 
 * `ifelse()` and `if_else()` now return missing values when their condition is
-  missing, consistently with base R and dplyr (#399, @Yousa-Mirage).
+  missing, consistent with base R and dplyr (#399, @Yousa-Mirage).
 
 * Fix the function name in deprecation warnings from `sink_csv()` (#393, @Yousa-Mirage).
 

--- a/R/funs-default.R
+++ b/R/funs-default.R
@@ -171,7 +171,7 @@ pl_floor <- function(x) {
   x$floor()
 }
 
-pl_ifelse <- function(test, yes, no, .data, ...) {
+pl_ifelse <- function(test, yes, no, .data, ..., missing = NULL) {
   check_empty_dots(...)
   env <- env_from_dots(...)
   expr_uses_col <- expr_uses_col_from_dots(...)
@@ -202,7 +202,21 @@ pl_ifelse <- function(test, yes, no, .data, ...) {
     caller = caller,
     expr_uses_col = expr_uses_col
   )
-  pl$when(test)$then(yes)$otherwise(no)
+  missing_expr <- enexpr(missing)
+  if (is_null(missing_expr)) {
+    missing_expr <- pl$lit(NA)
+  } else {
+    missing_expr <- translate_expr(
+      .data,
+      missing_expr,
+      new_vars = new_vars,
+      env = env,
+      caller = caller,
+      expr_uses_col = expr_uses_col
+    )
+  }
+
+  pl$when(test$is_null())$then(missing_expr)$when(test)$then(yes)$otherwise(no)
 }
 
 pl_is.finite <- function(x) {

--- a/R/utils-expr.R
+++ b/R/utils-expr.R
@@ -513,7 +513,9 @@ translate <- function(
         "ifelse" = ,
         "dplyr::if_else" = ,
         "if_else" = {
-          args <- call_args(expr)
+          is_if_else <- name %in% c("dplyr::if_else", "if_else")
+          fn <- if (is_if_else) dplyr::if_else else base::ifelse
+          args <- call_args(call_match(expr, fn))
           args$.data <- .data
           args[["__tidypolars__new_vars"]] <- as.list(new_vars)
           args[["__tidypolars__env"]] <- env

--- a/tests/testthat/_snaps/show_query-lazy.md
+++ b/tests/testthat/_snaps/show_query-lazy.md
@@ -1295,22 +1295,29 @@
           is_between(lower_bound = 2, upper_bound = 4, closed = "both"),
         co = pl$coalesce(pl$col("num"), pl$lit(0)),
         nr = (pl$col("num") - pl$lit(4))$abs() < 1.49011611938477e-08,
-        ie = pl$when(pl$col("num") > pl$lit(0))$
+        ie = pl$when((pl$col("num") > pl$lit(0))$is_null())$
+          then(pl$lit(NA))$
+          when(pl$col("num") > pl$lit(0))$
+          then(pl$lit("pos"))$
+          otherwise(pl$lit("neg")),
+        ie_missing = pl$when((pl$col("num") > pl$lit(0))$is_null())$
+          then(pl$lit("unknown"))$
+          when(pl$col("num") > pl$lit(0))$
           then(pl$lit("pos"))$
           otherwise(pl$lit("neg"))
       )
-      shape: (5, 12)
-      ┌──────┬─────┬─────┬─────────────┬───┬───────┬──────┬───────┬─────┐
-      │ num  ┆ int ┆ grp ┆ txt         ┆ … ┆ bt    ┆ co   ┆ nr    ┆ ie  │
-      │ ---  ┆ --- ┆ --- ┆ ---         ┆   ┆ ---   ┆ ---  ┆ ---   ┆ --- │
-      │ f64  ┆ i32 ┆ str ┆ str         ┆   ┆ bool  ┆ f64  ┆ bool  ┆ str │
-      ╞══════╪═════╪═════╪═════════════╪═══╪═══════╪══════╪═══════╪═════╡
-      │ 1.5  ┆ 2   ┆ a   ┆ Hello World ┆ … ┆ true  ┆ 1.5  ┆ false ┆ pos │
-      │ -2.3 ┆ 3   ┆ a   ┆ foo bar     ┆ … ┆ true  ┆ -2.3 ┆ false ┆ neg │
-      │ 4.0  ┆ 1   ┆ b   ┆ BAZ         ┆ … ┆ false ┆ 4.0  ┆ true  ┆ pos │
-      │ null ┆ 5   ┆ b   ┆ null        ┆ … ┆ false ┆ 0.0  ┆ null  ┆ neg │
-      │ 6.7  ┆ 4   ┆ a   ┆ a1b2        ┆ … ┆ true  ┆ 6.7  ┆ false ┆ pos │
-      └──────┴─────┴─────┴─────────────┴───┴───────┴──────┴───────┴─────┘
+      shape: (5, 13)
+      ┌──────┬─────┬─────┬─────────────┬───┬──────┬───────┬──────┬────────────┐
+      │ num  ┆ int ┆ grp ┆ txt         ┆ … ┆ co   ┆ nr    ┆ ie   ┆ ie_missing │
+      │ ---  ┆ --- ┆ --- ┆ ---         ┆   ┆ ---  ┆ ---   ┆ ---  ┆ ---        │
+      │ f64  ┆ i32 ┆ str ┆ str         ┆   ┆ f64  ┆ bool  ┆ str  ┆ str        │
+      ╞══════╪═════╪═════╪═════════════╪═══╪══════╪═══════╪══════╪════════════╡
+      │ 1.5  ┆ 2   ┆ a   ┆ Hello World ┆ … ┆ 1.5  ┆ false ┆ pos  ┆ pos        │
+      │ -2.3 ┆ 3   ┆ a   ┆ foo bar     ┆ … ┆ -2.3 ┆ false ┆ neg  ┆ neg        │
+      │ 4.0  ┆ 1   ┆ b   ┆ BAZ         ┆ … ┆ 4.0  ┆ true  ┆ pos  ┆ pos        │
+      │ null ┆ 5   ┆ b   ┆ null        ┆ … ┆ 0.0  ┆ null  ┆ null ┆ unknown    │
+      │ 6.7  ┆ 4   ┆ a   ┆ a1b2        ┆ … ┆ 6.7  ┆ false ┆ pos  ┆ pos        │
+      └──────┴─────┴─────┴─────────────┴───┴──────┴───────┴──────┴────────────┘
 
 # translated dplyr functions: case_when (with and without default)
 

--- a/tests/testthat/_snaps/show_query.md
+++ b/tests/testthat/_snaps/show_query.md
@@ -874,7 +874,14 @@
           is_between(lower_bound = 2, upper_bound = 4, closed = "both"),
         co = pl$coalesce(pl$col("num"), pl$lit(0)),
         nr = (pl$col("num") - pl$lit(4))$abs() < 1.49011611938477e-08,
-        ie = pl$when(pl$col("num") > pl$lit(0))$
+        ie = pl$when((pl$col("num") > pl$lit(0))$is_null())$
+          then(pl$lit(NA))$
+          when(pl$col("num") > pl$lit(0))$
+          then(pl$lit("pos"))$
+          otherwise(pl$lit("neg")),
+        ie_missing = pl$when((pl$col("num") > pl$lit(0))$is_null())$
+          then(pl$lit("unknown"))$
+          when(pl$col("num") > pl$lit(0))$
           then(pl$lit("pos"))$
           otherwise(pl$lit("neg"))
       )

--- a/tests/testthat/test-ifelse-lazy.R
+++ b/tests/testthat/test-ifelse-lazy.R
@@ -82,16 +82,16 @@ test_that("missing conditions work", {
 })
 
 test_that("ifelse() rejects the missing argument", {
-  test <- tibble(condition = c(TRUE, NA, FALSE))
-  test_pl <- as_polars_lf(test)
+  test_df <- tibble(condition = c(TRUE, NA, FALSE))
+  test_pl <- as_polars_lf(test_df)
 
   expect_both_error(
     test_pl |> mutate(out = ifelse(condition, 1, 0, missing = 2)),
-    test |> mutate(out = ifelse(condition, 1, 0, missing = 2))
+    test_df |> mutate(out = ifelse(condition, 1, 0, missing = 2))
   )
   expect_both_error(
     test_pl |> mutate(out = ifelse(condition, 1, 0, 2)),
-    test |> mutate(out = ifelse(condition, 1, 0, missing = 2))
+    test_df |> mutate(out = ifelse(condition, 1, 0, 2))
   )
 })
 

--- a/tests/testthat/test-ifelse-lazy.R
+++ b/tests/testthat/test-ifelse-lazy.R
@@ -51,13 +51,13 @@ test_that("basic behavior of if_else() works", {
 })
 
 test_that("missing conditions work", {
-  test <- tibble(
+  test_df <- tibble(
     condition = c(TRUE, NA, FALSE),
     true = c(1, 2, 3),
     false = c(4, 5, 6),
     missing = c(7, 8, 9)
   )
-  test_pl <- as_polars_lf(test)
+  test_pl <- as_polars_lf(test_df)
 
   expect_equal_lazy(
     test_pl |>
@@ -69,7 +69,7 @@ test_that("missing conditions work", {
         explicit = if_else(condition, true, false, missing = missing),
         positional = if_else(condition, true, false, missing)
       ),
-    test |>
+    test_df |>
       mutate(
         base = ifelse(condition, true, false),
         base_qualified = base::ifelse(condition, true, false),

--- a/tests/testthat/test-ifelse-lazy.R
+++ b/tests/testthat/test-ifelse-lazy.R
@@ -50,6 +50,51 @@ test_that("basic behavior of if_else() works", {
   )
 })
 
+test_that("missing conditions work", {
+  test <- tibble(
+    condition = c(TRUE, NA, FALSE),
+    true = c(1, 2, 3),
+    false = c(4, 5, 6),
+    missing = c(7, 8, 9)
+  )
+  test_pl <- as_polars_lf(test)
+
+  expect_equal_lazy(
+    test_pl |>
+      mutate(
+        base = ifelse(condition, true, false),
+        base_qualified = base::ifelse(condition, true, false),
+        default = if_else(condition, true, false),
+        default_qualified = dplyr::if_else(condition, true, false),
+        explicit = if_else(condition, true, false, missing = missing),
+        positional = if_else(condition, true, false, missing)
+      ),
+    test |>
+      mutate(
+        base = ifelse(condition, true, false),
+        base_qualified = base::ifelse(condition, true, false),
+        default = if_else(condition, true, false),
+        default_qualified = dplyr::if_else(condition, true, false),
+        explicit = if_else(condition, true, false, missing = missing),
+        positional = if_else(condition, true, false, missing)
+      )
+  )
+})
+
+test_that("ifelse() rejects the missing argument", {
+  test <- tibble(condition = c(TRUE, NA, FALSE))
+  test_pl <- as_polars_lf(test)
+
+  expect_both_error(
+    test_pl |> mutate(out = ifelse(condition, 1, 0, missing = 2)),
+    test |> mutate(out = ifelse(condition, 1, 0, missing = 2))
+  )
+  expect_both_error(
+    test_pl |> mutate(out = ifelse(condition, 1, 0, 2)),
+    test |> mutate(out = ifelse(condition, 1, 0, missing = 2))
+  )
+})
+
 test_that("if_else() and ifelse() work with named args", {
   test_df <- tibble(
     x1 = c("a", "a", "b", "a", "c"),

--- a/tests/testthat/test-ifelse.R
+++ b/tests/testthat/test-ifelse.R
@@ -46,6 +46,51 @@ test_that("basic behavior of if_else() works", {
   )
 })
 
+test_that("missing conditions work", {
+  test <- tibble(
+    condition = c(TRUE, NA, FALSE),
+    true = c(1, 2, 3),
+    false = c(4, 5, 6),
+    missing = c(7, 8, 9)
+  )
+  test_pl <- as_polars_df(test)
+
+  expect_equal(
+    test_pl |>
+      mutate(
+        base = ifelse(condition, true, false),
+        base_qualified = base::ifelse(condition, true, false),
+        default = if_else(condition, true, false),
+        default_qualified = dplyr::if_else(condition, true, false),
+        explicit = if_else(condition, true, false, missing = missing),
+        positional = if_else(condition, true, false, missing)
+      ),
+    test |>
+      mutate(
+        base = ifelse(condition, true, false),
+        base_qualified = base::ifelse(condition, true, false),
+        default = if_else(condition, true, false),
+        default_qualified = dplyr::if_else(condition, true, false),
+        explicit = if_else(condition, true, false, missing = missing),
+        positional = if_else(condition, true, false, missing)
+      )
+  )
+})
+
+test_that("ifelse() rejects the missing argument", {
+  test <- tibble(condition = c(TRUE, NA, FALSE))
+  test_pl <- as_polars_df(test)
+
+  expect_both_error(
+    test_pl |> mutate(out = ifelse(condition, 1, 0, missing = 2)),
+    test |> mutate(out = ifelse(condition, 1, 0, missing = 2))
+  )
+  expect_both_error(
+    test_pl |> mutate(out = ifelse(condition, 1, 0, 2)),
+    test |> mutate(out = ifelse(condition, 1, 0, missing = 2))
+  )
+})
+
 test_that("if_else() and ifelse() work with named args", {
   test_df <- tibble(
     x1 = c("a", "a", "b", "a", "c"),

--- a/tests/testthat/test-ifelse.R
+++ b/tests/testthat/test-ifelse.R
@@ -78,16 +78,16 @@ test_that("missing conditions work", {
 })
 
 test_that("ifelse() rejects the missing argument", {
-  test <- tibble(condition = c(TRUE, NA, FALSE))
-  test_pl <- as_polars_df(test)
+  test_df <- tibble(condition = c(TRUE, NA, FALSE))
+  test_pl <- as_polars_df(test_df)
 
   expect_both_error(
     test_pl |> mutate(out = ifelse(condition, 1, 0, missing = 2)),
-    test |> mutate(out = ifelse(condition, 1, 0, missing = 2))
+    test_df |> mutate(out = ifelse(condition, 1, 0, missing = 2))
   )
   expect_both_error(
     test_pl |> mutate(out = ifelse(condition, 1, 0, 2)),
-    test |> mutate(out = ifelse(condition, 1, 0, missing = 2))
+    test_df |> mutate(out = ifelse(condition, 1, 0, 2))
   )
 })
 

--- a/tests/testthat/test-ifelse.R
+++ b/tests/testthat/test-ifelse.R
@@ -47,13 +47,13 @@ test_that("basic behavior of if_else() works", {
 })
 
 test_that("missing conditions work", {
-  test <- tibble(
+  test_df <- tibble(
     condition = c(TRUE, NA, FALSE),
     true = c(1, 2, 3),
     false = c(4, 5, 6),
     missing = c(7, 8, 9)
   )
-  test_pl <- as_polars_df(test)
+  test_pl <- as_polars_df(test_df)
 
   expect_equal(
     test_pl |>
@@ -65,7 +65,7 @@ test_that("missing conditions work", {
         explicit = if_else(condition, true, false, missing = missing),
         positional = if_else(condition, true, false, missing)
       ),
-    test |>
+    test_df |>
       mutate(
         base = ifelse(condition, true, false),
         base_qualified = base::ifelse(condition, true, false),

--- a/tests/testthat/test-show_query-lazy.R
+++ b/tests/testthat/test-show_query-lazy.R
@@ -699,7 +699,8 @@ test_that("translated dplyr functions: between, coalesce, near, if_else", {
       bt = between(int, 2, 4),
       co = coalesce(num, 0),
       nr = near(num, 4),
-      ie = if_else(num > 0, "pos", "neg")
+      ie = if_else(num > 0, "pos", "neg"),
+      ie_missing = if_else(num > 0, "pos", "neg", missing = "unknown")
     )
 
   expect_snapshot_lazy(show_query(query))

--- a/tests/testthat/test-show_query.R
+++ b/tests/testthat/test-show_query.R
@@ -695,7 +695,8 @@ test_that("translated dplyr functions: between, coalesce, near, if_else", {
       bt = between(int, 2, 4),
       co = coalesce(num, 0),
       nr = near(num, 4),
-      ie = if_else(num > 0, "pos", "neg")
+      ie = if_else(num > 0, "pos", "neg"),
+      ie_missing = if_else(num > 0, "pos", "neg", missing = "unknown")
     )
 
   expect_snapshot(show_query(query))

--- a/vignettes/supported-functions.Rmd
+++ b/vignettes/supported-functions.Rmd
@@ -210,6 +210,8 @@ out <- tribble(
         "`tidypolars` cannot use several timezones in a single column, while `lubridate::force_tz()` can.",
       Package == "`dplyr`" & Function == "`near`" ~
         "tidypolars errors if `x` and `y` have different lengths, dplyr doesn't.",
+      Package == "`dplyr`" & Function == "`if_else`" ~
+        "The `missing` argument is supported, but `ptype` and `size` are not.",
       Package == "`dplyr`" & Function == "`row_number`" ~
         "Doesn't work when `x` is missing.",
       Package == "`dplyr`" & Function %in% c("`recode_values`", "`replace_values`") ~

--- a/vignettes/supported-functions.Rmd
+++ b/vignettes/supported-functions.Rmd
@@ -211,7 +211,7 @@ out <- tribble(
       Package == "`dplyr`" & Function == "`near`" ~
         "tidypolars errors if `x` and `y` have different lengths, dplyr doesn't.",
       Package == "`dplyr`" & Function == "`if_else`" ~
-        "The `missing` argument is supported, but `ptype` and `size` are not.",
+        "The arguments `ptype` and `size` are not supported.",
       Package == "`dplyr`" & Function == "`row_number`" ~
         "Doesn't work when `x` is missing.",
       Package == "`dplyr`" & Function %in% c("`recode_values`", "`replace_values`") ~


### PR DESCRIPTION
- Added support for the `missing` argument in `if_else()`
- `ifelse()` and `if_else()` now return missing values when their condition is missing, consistently with base R and dplyr
- Add more tests

``` r
library(dplyr)
library(tidypolars)

df <- tibble(test = c(TRUE, NA, FALSE))
df_pl <- as_polars_df(df)

df |> mutate(out = ifelse(test, 1, 0))
#> # A tibble: 3 × 2
#>   test    out
#>   <lgl> <dbl>
#> 1 TRUE      1
#> 2 NA       NA
#> 3 FALSE     0
df_pl |> mutate(out = ifelse(test, 1, 0))
#> shape: (3, 2)
#> ┌───────┬─────┐
#> │ test  ┆ out │
#> │ ---   ┆ --- │
#> │ bool  ┆ f64 │
#> ╞═══════╪═════╡
#> │ true  ┆ 1.0 │
#> │ null  ┆ 0.0 │
#> │ false ┆ 0.0 │
#> └───────┴─────┘

df |> mutate(out = if_else(test, 1, 0, missing = 999))
#> # A tibble: 3 × 2
#>   test    out
#>   <lgl> <dbl>
#> 1 TRUE      1
#> 2 NA      999
#> 3 FALSE     0
df_pl |> mutate(out = if_else(test, 1, 0, missing = 999))
#> Warning: tidypolars doesn't know how to use some arguments of .
#> ℹ The following argument(s) will be ignored: "missing".
#> shape: (3, 2)
#> ┌───────┬─────┐
#> │ test  ┆ out │
#> │ ---   ┆ --- │
#> │ bool  ┆ f64 │
#> ╞═══════╪═════╡
#> │ true  ┆ 1.0 │
#> │ null  ┆ 0.0 │
#> │ false ┆ 0.0 │
#> └───────┴─────┘
```

